### PR TITLE
Schedule metrics DAG later in the day

### DIFF
--- a/dgv/metrics/DAG.py
+++ b/dgv/metrics/DAG.py
@@ -31,7 +31,7 @@ default_args = {
 
 with DAG(
     dag_id=DAG_NAME,
-    schedule_interval='15 3 * * *',
+    schedule_interval='15 6 * * *',
     start_date=days_ago(1),
     catchup=False,
     dagrun_timeout=timedelta(minutes=60 * 8),


### PR DESCRIPTION
It should start only once the data.gouv.fr catalogs have been updated.