### PR TITLE
[DAG siren geocodage] feat: add tests to sirene geoloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 */__pycache__/
 schema/tmp/
 .DS_Store
+.pre-commit-config.yaml

--- a/data_processing/insee/sirene/geocodage/README.md
+++ b/data_processing/insee/sirene/geocodage/README.md
@@ -6,8 +6,12 @@
 | -------- | -------- |
 | Fichier source     | `DAG-sirene-geocodage-etalab.py`     |
 | Description | DAG Airflow qui récupère les données de la base SIRENE publiées sur data.gouv.fr et lance un géocodage basé sur la BAL. Ce DAG dure plusieurs heures et dépose les fichiers sur files.data.gouv.fr/geo-sirene|
-| Fréquence de mise à jour |  Mensuel (le 1er du mois) |
+| Fréquence de mise à jour |  Mensuel (les 1er, 5 et 10 du mois) |
 | Données sources | [JDD INSEE data.gouv.fr](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/) |
 | Données de sorties | [JDD Etalab data.gouv.fr](https://www.data.gouv.fr/fr/datasets/base-sirene-des-etablissements-siret-geolocalisee-avec-la-base-dadresse-nationale-ban/) |
 | Channel Mattermost d'information | ~startup-datagouv-dataeng |
 
+## Fichiers d'exécutions
+
+L'ensemble des fichiers situés dans le dossier `remote_files` sont des copies des fichiers stockés sur le serveur distant et appelés par SSH dans le DAG.
+Ils sont présents dans le dépôt à titre informatif et sont maintenus à jours manuellement.

--- a/data_processing/insee/sirene/geocodage/remote_files/1_download_last_sirene_batch.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/1_download_last_sirene_batch.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+cd /srv/sirene/data-sirene/
+rm -rf data/*
+rm Stock*
+rm -rf communes/*
+echo "Downloading last SIRENE batch..." # ------------------------------------------------------
+wget -N https://files.data.gouv.fr/insee-sirene/StockEtablissement_utf8.zip
+echo "Download OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/2_split_departments_files.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/2_split_departments_files.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+cd /srv/sirene/data-sirene/
+echo "Splitting in one file per department"
+mkdir /srv/sirene/data-sirene/data/
+rm -f /srv/sirene/data-sirene/data/dep_*.csv
+unzip -p /srv/sirene/data-sirene/StockEtablissement_utf8.zip | awk -v FPAT='[^,]*|"([^"]|"")*"' '{ print >> "/srv/sirene/data-sirene/data/dep_"substr($23,1,2)".csv"}'
+awk -v FPAT='[^,]*|"([^"]|"")*"' '{ print >> "/srv/sirene/data-sirene/data/dep_"$23".csv"}' /srv/sirene/data-sirene/data/dep_75.csv
+awk -v FPAT='[^,]*|"([^"]|"")*"' '{ print >> "/srv/sirene/data-sirene/data/dep_"substr($23,1,3)".csv"}' /srv/sirene/data-sirene/data/dep_97.csv
+rm -f /srv/sirene/data-sirene/data/dep_75.csv /srv/sirene/data-sirene/data/dep_97.csv /srv/sirene/data-sirene/data/dep_co.csv
+echo "Split OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/3_geocoding_by_increasing_size.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/3_geocoding_by_increasing_size.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+echo "Geocoding by increasing size of departments"
+cd /srv/sirene/geocodage-sirene/
+# extrait la liste des anciens codes INSEE et nouveau correspondant
+csvgrep -c POLE -r '^.+$' -t /srv/sirene/geocodage-sirene/France2018.tsv -e iso8859-1 | csvcut -c 6,7,11,14 | sed 's/,//' > /srv/sirene/geocodage-sirene/histo_depcom.csv
+time wc -l /srv/sirene/data-sirene/data/dep_*.csv | sort -n -r | grep dep | sed 's/^.*_\(.*\).csv/\1/' | \
+  parallel -j 36 -t /srv/sirene/venv/bin/python /srv/sirene/geocodage-sirene/geocode.py /srv/sirene/data-sirene/data/dep_{}.csv /srv/sirene/data-sirene/data/geo_siret_{}.csv.gz /srv/sirene/data-sirene/cache_geo/cache_addok_sirene_{}.csv.db \> /srv/sirene/data-sirene/data/geo_siret_{}.log
+echo "Geocode OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/4a_split_by_locality.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/4a_split_by_locality.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+echo "Splitting by locality"
+cd /srv/sirene/data-sirene/data
+ls -1 geo_siret_*.csv.gz | parallel sh /srv/sirene/geocodage-sirene/communes_split.sh {}
+echo "Split OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/4b_geocode_stats.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/4b_geocode_stats.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+echo "Store performance stats of geocoding"
+grep final -h /srv/sirene/data-sirene/data/*.log | jq -s '.' > /srv/sirene/data-sirene/stats.json
+tar czf data/logs.tgz data/*.log
+echo "Store performance OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/4c_check_stats_coherence.py
+++ b/data_processing/insee/sirene/geocodage/remote_files/4c_check_stats_coherence.py
@@ -1,0 +1,150 @@
+import json
+from datetime import datetime
+from typing import Dict, List
+
+
+def load_json(file_path: str):
+    with open(file_path, "r") as f:
+        return json.load(f)
+
+
+def get_missing_geo_files(dict_to_compare: Dict, dict_baseline: Dict) -> List[str]:
+    """
+    Returns:
+        List[str]: list of all the files missing from the dict_to_compare dictionary
+    """
+    return [
+        geo_file_path.split("/")[-1]
+        for geo_file_path in set(dict_baseline.keys() - set(dict_to_compare.keys()))
+    ]
+
+
+def get_previous_year_month_string() -> str:
+    """
+    Returns:
+        str: the previous month with the format YYYY-MM
+    """
+    current_date = datetime.now()
+    previous_month = current_date.month - 1
+    previous_year = current_date.year
+    if previous_month == 0:
+        previous_month = 12
+        previous_year -= 1
+    return f"{previous_year}-{previous_month:02d}"
+
+
+def compare_stats(
+    stats_prev_json, stats_next_json, thresholds: Dict[str, int]
+) -> List[str]:
+    """
+    Compare stats between two JSON files.
+    The json looks like:
+    [{
+        "action": "final",
+        "count": 102317,
+        "efficacite": 80.94,
+        "fichier": "/srv/sirene/data-sirene/data/dep_70.csv",
+        "geocode_cache": 96207,
+        "geocode_count": 13425,
+        "geocode_score_avg": 0.9073401380827498,
+        "geocode_score_variance": 0.013120856986200129,
+        "housenumber": 62967,
+        "interpolation": 478,
+        "locality": 939,
+        "municipality": 15,
+        "poi": 1345,
+        "street": 17073,
+        "townhall": 0,
+        "vide": 0
+    }, {...}]
+
+    Args:
+        json1 (list): Parsed content of the first JSON file.
+        json2 (list): Parsed content of the second JSON file.
+        thresholds (dict): Thresholds for acceptable percentage change.
+
+    Returns:
+        list: Issues found during comparison.
+    """
+
+    stats_prev = {item["fichier"]: item for item in stats_prev_json}
+    stats_next = {item["fichier"]: item for item in stats_next_json}
+
+    results = []
+
+    common_files = set(stats_prev.keys()).intersection(stats_next.keys())
+    for geo_file_path in common_files:
+        geo_file = geo_file_path.split("/")[-1]
+        for key in thresholds.keys():
+            if key in stats_prev[geo_file_path] and key in stats_next[geo_file_path]:
+                value_prev = stats_prev[geo_file_path][key]
+                value_next = stats_next[geo_file_path][key]
+                if value_prev == 0:  # No division by 0
+                    results.append(
+                        f"[OK]\t{geo_file}: '{key}' went from {value_prev} to {value_next}"
+                    )
+                    continue
+                delta = (value_next - value_prev) / value_prev * 100
+                threshold = thresholds.get(key, 100)
+                # Example: a delta of -30% for a threshold of -20% raise an error
+                if threshold > delta:
+                    results.append(
+                        f"[ERROR]\t{geo_file}: '{key}' went from {value_prev} to {value_next} "
+                        f"= {delta:.2f}% (threshold: {threshold}%)"
+                    )
+                else:
+                    results.append(
+                        f"[OK]\t{geo_file}: '{key}' went from {value_prev} to {value_next} "
+                        f"= {delta:.2f}% (threshold: {threshold}%)"
+                    )
+
+    # Find missing "fichiers" keys
+    missing_in_json_prev = get_missing_geo_files(stats_prev, stats_next)
+    if missing_in_json_prev:
+        results.append(
+            f"[ERROR] Geo files missing in the old stats: {', '.join(missing_in_json_prev)}"
+        )
+
+    missing_in_json_next = get_missing_geo_files(stats_next, stats_prev)
+    if missing_in_json_next:
+        results.append(
+            f"[ERROR] Geo files missing in the new stats: {', '.join(missing_in_json_next)}"
+        )
+
+    return results
+
+
+def check_stats_coherence(file_prev: str, file_next: str) -> None:
+    file_prev = load_json(file_prev)
+    file_next = load_json(file_next)
+
+    thresholds = {
+        "count": -5,  # if the new count is under -5% of the previous one then raises an error
+        "locality": -10,
+        "efficacite": -10,  # efficacite = ratio of successful geocodage
+    }
+
+    results = compare_stats(file_prev, file_next, thresholds)
+
+    error_code = 0
+    for result in results:
+        print(result)
+        if result.startswith("[ERROR]"):
+            error_code = 1
+
+    if error_code:
+        print("Stats are not coherent.")
+    else:
+        print("Stats are coherent.")
+
+    # TODO: After running at least once in production
+    # Change the print code to:
+    # exit(error_code)
+    print(f"Error Code: {error_code}")
+
+
+if __name__ == "__main__":
+    previous_month_string = get_previous_year_month_string()
+    file_prev = f"/srv/sirene/data-sirene/{previous_month_string}/stats.json"
+    file_next = "/srv/sirene/data-sirene/stats.json"
+    check_stats_coherence(file_prev, file_next)

--- a/data_processing/insee/sirene/geocodage/remote_files/5_national_files_agregation.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/5_national_files_agregation.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+echo "Agregating national files"
+zcat /srv/sirene/data-sirene/data/geo_siret_01.csv.gz | head -n 1 | gzip -9 --rsyncable > /srv/sirene/data-sirene/StockEtablissement_utf8_geo.csv.gz
+for f in /srv/sirene/data-sirene/data/geo_siret*.csv.gz; do zcat "$f" | tail -n +2 | gzip -9 --rsyncable >> /srv/sirene/data-sirene/StockEtablissement_utf8_geo.csv.gz ; done
+# fichier séparé pour établissements actifs/fermés seuls
+zcat /srv/sirene/data-sirene/StockEtablissement_utf8_geo.csv.gz \
+| tee >(csvgrep -c etatAdministratifEtablissement -m "A" | gzip -9 --rsyncable > /srv/sirene/data-sirene/StockEtablissementActif_utf8_geo.csv.gz) >(csvgrep -c etatAdministratifEtablissement -m "F" | gzip -9 --rsyncable > /srv/sirene/data-sirene/StockEtablissementFerme_utf8_geo.csv.gz) > /dev/null
+echo "National files agregation OK!"

--- a/data_processing/insee/sirene/geocodage/remote_files/6_prepare_to_rsync.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/6_prepare_to_rsync.sh
@@ -1,0 +1,7 @@
+mkdir /srv/sirene/data-sirene/$(date +%Y-%m)
+mkdir /srv/sirene/data-sirene/$(date +%Y-%m)/dep
+mkdir /srv/sirene/data-sirene/$(date +%Y-%m)/communes
+mv /srv/sirene/data-sirene/Stock*.csv.gz /srv/sirene/data-sirene/$(date +%Y-%m)/
+mv /srv/sirene/data-sirene/data/geo*.csv.gz /srv/sirene/data-sirene/$(date +%Y-%m)/dep/
+mv /srv/sirene/data-sirene/communes/* /srv/sirene/data-sirene/$(date +%Y-%m)/communes/
+mv /srv/sirene/data-sirene/stats.json /srv/sirene/data-sirene/$(date +%Y-%m)/

--- a/data_processing/insee/sirene/geocodage/remote_files/7_rsync_to_files_data_gouv.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/7_rsync_to_files_data_gouv.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rsync -a --rsync-path="mkdir -p /srv/nfs/files.data.gouv.fr/geo-sirene/$(date +%Y-%m) && rsync" /srv/sirene/data-sirene/$(date +%Y-%m)/ root@files.data.gouv.fr:/srv/nfs/files.data.gouv.fr/geo-sirene/$(date +%Y-%m)/

--- a/data_processing/insee/sirene/geocodage/remote_files/communes_split.sh
+++ b/data_processing/insee/sirene/geocodage/remote_files/communes_split.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+echo $1
+mkdir -p /srv/sirene/data-sirene/communes
+
+# entête des fichiers CSV par commune
+HEAD=$(zcat $1 | head -n 1)
+for i in `zcat $1 | csvcut -c codeCommuneEtablissement | sort -u | grep '^[0-9]'`; do
+  echo $HEAD > /srv/sirene/data-sirene/communes/$i.csv;
+done
+
+# split des fichiers
+zcat $1 | tail -n +2 | awk -v FPAT='[^,]*|"([^"]|"")*"' '{print >> "/srv/sirene/data-sirene/communes/"$23".csv"}'

--- a/data_processing/insee/sirene/geocodage/remote_files/geocode.py
+++ b/data_processing/insee/sirene/geocodage/remote_files/geocode.py
@@ -1,0 +1,482 @@
+#! /usr/bin/python3
+import sys
+import csv
+import json
+import re
+import gzip
+
+# modules installés par pip
+import requests
+import sqlite3
+import marshal
+import unidecode
+import random
+
+# modules locaux
+from normadresse.normadresse import abrev
+
+score_min = 0.30
+
+# URL à appeler pour géocodage BAN, BANO et POI OSM
+# addok_ban = ['http://localhost:7878/search/','http://localhost:7879/search/','http://localhost:7880/search/','http://localhost:7881/search/','http://localhost:7882/search/','http://localhost:7883/search/','http://localhost:7884/search/','http://localhost:7885/search/','http://localhost:7886/search/','http://localhost:7887/search/']
+
+addok_ban = ['http://localhost:7878/search/','http://localhost:7879/search/','http://localhost:7880/search/','http://localhost:7881/search/','http://localhost:7882/search/','http://localhost:7883/search/']
+
+addok_poi = 'http://localhost:7830/search'
+
+geocode_count = 0
+
+# effecture une req. sur l'API de géocodage
+def geocode(api, params, l4):
+    params['autocomplete'] = 0
+    params['q'] = params['q'].strip()
+    try:
+        r = requests.get(api, params)
+        j = json.loads(r.text)
+        global geocode_count
+        geocode_count += 1
+        if 'features' in j and len(j['features']) > 0:
+            j['features'][0]['l4'] = l4
+            j['features'][0]['geo_l4'] = ''
+            j['features'][0]['geo_l5'] = ''
+            if api != addok_poi:
+                # regénération lignes 4 et 5 normalisées
+                name = j['features'][0]['properties']['name']
+
+                ligne4 = re.sub(r'\(.*$', '', name).strip()
+                ligne4 = re.sub(r',.*$', '', ligne4).strip()
+                ligne5 = ''
+                j['features'][0]['geo_l4'] = abrev(ligne4).upper()
+                if '(' in name:
+                    ligne5 = re.sub(r'.*\((.*)\)', r'\1', name).strip()
+                    j['features'][0]['geo_l5'] = abrev(ligne5).upper()
+                if ',' in name:
+                    ligne5 = re.sub(r'.*,(.*)', r'\1', name).strip()
+                    j['features'][0]['geo_l5'] = abrev(ligne5).upper()
+                # ligne 4 et 5 identiques ? on supprime la 5
+                if j['features'][0]['geo_l5'] == j['features'][0]['geo_l4']:
+                    j['features'][0]['geo_l5'] = ''
+            return(j['features'][0])
+        else:
+            return(None)
+    except:
+        print(json.dumps({'action': 'erreur', 'api': api,
+                         'params': params, 'l4': l4}))
+        return(None)
+
+
+def trace(txt):
+    if False:
+        print(txt)
+
+
+if len(sys.argv) > 2:
+    stock = False
+    sirene_csv = csv.reader(open(sys.argv[1], 'r', encoding='utf-8'), delimiter=',')
+    sirene_geo = csv.writer(gzip.open(sys.argv[2], 'wt', encoding='utf-8', compresslevel=9))
+    conn = None
+    if len(sys.argv) > 3:
+        print(sys.argv[3])
+        conn = sqlite3.connect(sys.argv[3])
+        conn.execute('''CREATE TABLE IF NOT EXISTS cache_addok (adr text, geo text,
+                     score numeric)''')
+        conn.execute('CREATE INDEX IF NOT EXISTS cache_addok_adr ON cache_addok (adr)')  # noqa
+        conn.execute('DELETE FROM cache_addok WHERE score<0.7')
+else:
+    stock = True
+    sirene_csv = csv.reader(open(sys.argv[1], 'r'))
+    sirene_geo = csv.writer(open('geo-'+sys.argv[1], 'w'))
+    conn = sqlite3.connect('cache_geo/cache_addok_'+sys.argv[1]+'.db')
+    conn.execute('''CREATE TABLE IF NOT EXISTS cache_addok (adr text, geo text,
+                 score numeric)''')
+    conn.execute('CREATE INDEX IF NOT EXISTS cache_addok_adr ON cache_addok (adr)')  # noqa
+    conn.execute('DELETE FROM cache_addok WHERE score<0.7')
+
+# chargement de la liste des communes et lat/lon
+communes = csv.DictReader(open('communes-plus-20140630.csv', 'r'))
+commune_insee = {}
+for commune in communes:
+    commune_insee[commune['\ufeffinsee']] = {'lat': round(float(commune['lon_centro']), 6),
+                                             'lon': round(float(commune['lat_centro']), 6)}
+
+# chargement des changements de codes INSEE
+histo = csv.DictReader(open('histo_depcom.csv', 'r'))
+histo_depcom = {}
+for commune in histo:
+    histo_depcom[commune['DEPCOM']] = commune
+
+header = None
+ok = 0
+total = 0
+cache = 0
+numbers = re.compile('(^[0-9]*)')
+stats = {'action': 'progress', 'housenumber': 0, 'interpolation': 0,
+         'street': 0, 'locality': 0, 'municipality': 0, 'vide': 0,
+         'townhall': 0, 'poi': 0, 'fichier': sys.argv[1]}
+score_total = 0
+score_count = 0
+score_variance = 0
+
+# regexp souvent utilisées
+ccial = r'((C|CTRE|CENTRE|CNTRE|CENT|ESPACE) (CCIAL|CIAL|COM|COMM|COMMERC|COMMERCIAL)|CCR|C\.CIAL|C\.C|CCIAL|CC)'  # noqa
+
+header = [
+    'siren',
+    'nic',
+    'siret',
+    'statutDiffusionEtablissement',
+    'dateCreationEtablissement',
+    'trancheEffectifsEtablissement',
+    'anneeEffectifsEtablissement',
+    'activitePrincipaleRegistreMetiersEtablissement',
+    'dateDernierTraitementEtablissement',
+    'etablissementSiege',
+    'nombrePeriodesEtablissement',
+    'complementAdresseEtablissement',
+    'numeroVoieEtablissement',
+    'indiceRepetitionEtablissement',
+    'dernierNumeroVoieEtablissement',
+    'indiceRepetitionDernierNumeroVoieEtablissement',
+    'typeVoieEtablissement',
+    'libelleVoieEtablissement',
+    'codePostalEtablissement',
+    'libelleCommuneEtablissement',
+    'libelleCommuneEtrangerEtablissement',
+    'distributionSpecialeEtablissement',
+    'codeCommuneEtablissement',
+    'codeCedexEtablissement',
+    'libelleCedexEtablissement',
+    'codePaysEtrangerEtablissement',
+    'libellePaysEtrangerEtablissement',
+    'identifiantAdresseEtablissement',
+    'coordonneeLambertAbscisseEtablissement',
+    'coordonneeLambertOrdonneeEtablissement',
+    'complementAdresse2Etablissement',
+    'numeroVoie2Etablissement',
+    'indiceRepetition2Etablissement',
+    'typeVoie2Etablissement',
+    'libelleVoie2Etablissement',
+    'codePostal2Etablissement',
+    'libelleCommune2Etablissement',
+    'libelleCommuneEtranger2Etablissement',
+    'distributionSpeciale2Etablissement',
+    'codeCommune2Etablissement',
+    'codeCedex2Etablissement',
+    'libelleCedex2Etablissement',
+    'codePaysEtranger2Etablissement',
+    'libellePaysEtranger2Etablissement',
+    'dateDebut',
+    'etatAdministratifEtablissement',
+    'enseigne1Etablissement',
+    'enseigne2Etablissement',
+    'enseigne3Etablissement',
+    'denominationUsuelleEtablissement',
+    'activitePrincipaleEtablissement',
+    'nomenclatureActivitePrincipaleEtablissement',
+    'caractereEmployeurEtablissement',
+    'longitude',
+    'latitude',
+    'geo_score',
+    'geo_type',
+    'geo_adresse',
+    'geo_id',
+    'geo_ligne',
+    'geo_l4',
+    'geo_l5'
+]
+
+sirene_geo.writerow(header)
+
+test = 0
+test2 = 0
+for et in sirene_csv:
+    # ban_number = random.randint(0,8)
+    ban_number = random.randint(0,5)
+    # on ne tente pas le géocodage des adresses hors de France
+    if et[22] == '' or re.match(r'^(978|98|99)',et[20]):
+        row = et+['', '', 0, '', '', '', '', '', '']
+        sirene_geo.writerow(row)
+    else:
+        total = total + 1
+        # fichier SIRENE (stock et quotidien)
+        #  géocodage de l'adresse géographique
+        #  au cas où numvoie contiendrait autre chose que des chiffres...
+        numvoie = numbers.match(et[12]).group(0)
+        indrep = et[13]
+        typvoie = et[16]
+        libvoie = et[17]
+        ligne4N = ''
+        ligne4D = ''
+        # code INSEE de la commune
+        depcom = et[22]
+
+        if numvoie == '' and numbers.match(libvoie).group(0):
+            numvoie = numbers.match(libvoie).group(0)
+            libvoie = libvoie[len(numvoie):]
+
+        # typvoie incorrect ou à désabréger pour un score cohérent
+        typ_abrege = {'PRO': 'PROMENADE',
+                      'AV': 'AVENUE',
+                      'BD': 'BOULEVARD',
+                      'PL': 'PLACE',
+                      'CAR': 'CARREFOUR',
+                      'PAS': 'PASSAGE',
+                      'IMP': 'IMPASSE'}
+        if typvoie in typ_abrege:
+            typvoie == typ_abrege[typvoie]
+
+        # élimination des LD / LIEU-DIT des libellés
+        if typvoie in ['LD', 'HAM']:
+            typvoie = ''
+        libvoie = re.sub(r'^PRO ', 'PROMENADE ', libvoie)
+        libvoie = re.sub(r'^(LD|HAM|HAMMEAU) ', '', libvoie)
+        libvoie = re.sub(r'^LIEU(.|)DIT ', '', libvoie)
+        libvoie = re.sub(r'^ADRESSE INCOMPLETE.*', '', libvoie)
+        libvoie = re.sub(r'^SANS DOMICILE FIXE', '', libvoie)
+        libvoie = re.sub(r'^COMMUNE DE RATTACHEMENT', '', libvoie)
+
+        # code insee inconnu ?
+        if depcom != '' and depcom < '97000' and depcom in histo_depcom:
+            if libvoie != '':
+                libvoie = libvoie + " " + histo_depcom[depcom]['NCC']
+            depcom = histo_depcom[depcom]['POLE']
+
+        # ou de la ligne 4 normalisée
+        ligne4G = ('%s%s %s %s' % (numvoie, indrep, typvoie, libvoie)).strip()
+        if et[11] != '':
+            ligne4D = ('%s%s %s %s %s' % (numvoie, indrep, typvoie, libvoie, et[11])).strip()
+
+        try:
+            cursor = conn.execute('SELECT * FROM cache_addok WHERE adr=?',
+                                  ('%s|%s|%s|%s' % (depcom, ligne4G,
+                                                    ligne4N, ligne4D), ))
+            g = cursor.fetchone()
+        except:
+            g = None
+        if g is not None:
+            test = test + 1
+            source = marshal.loads(g[1])
+            cache = cache+1
+        else:
+            test2 = test2 + 1
+            trace('%s / %s / %s' % (ligne4G, ligne4D, ligne4N))
+
+            # géocodage BAN (ligne4 géo, déclarée ou normalisée si pas trouvé
+            # ou score insuffisant)
+            ban = None
+            if ligne4G != '':
+                ban = geocode(addok_ban[ban_number], {'q': ligne4G, 'citycode': depcom,
+                                          'limit': '1'}, 'G')
+            if (ban is None or ban['properties']['score'] < score_min
+               and ligne4N != ligne4G and ligne4N != ''):
+                ban = geocode(addok_ban[ban_number], {'q': ligne4N, 'citycode': depcom,
+                                          'limit': '1'}, 'N')
+                trace('+ ban  L4N')
+            if (ban is None or ban['properties']['score'] < score_min
+               and ligne4D != ligne4N and ligne4D != ligne4G
+               and ligne4D != ''):
+                ban = geocode(addok_ban[ban_number], {'q': ligne4D, 'citycode': depcom,
+                                          'limit': '1'}, 'D')
+                trace('+ ban  L4D')
+
+            if ban is not None:
+                ban_score = ban['properties']['score']
+                ban_type = ban['properties']['type']
+                if ['village', 'town', 'city'].count(ban_type) > 0:
+                    ban_type = 'municipality'
+            else:
+                ban_score = 0
+                ban_type = ''
+
+
+            # choix de la source
+            source = None
+            score = 0
+
+            # on a un numéro... on cherche dessus
+            if numvoie != '':
+                # numéro trouvé dans les deux bases, on prend BAN
+                # sauf si score inférieur de 20% à BANO
+                if (ban_type == 'housenumber' and ban_score > score_min):
+                    source = ban
+                    score = ban['properties']['score']
+                # on cherche une interpollation dans BAN
+                elif ban is None or ban_type == 'street' and int(numvoie) > 2:
+                    ban_avant = geocode(addok_ban[ban_number], {'q': '%s %s %s' % (int(numvoie)-2, typvoie, libvoie), 'citycode': depcom, 'limit': '1'}, 'G')
+                    ban_apres = geocode(addok_ban[ban_number], {'q': '%s %s %s' % (int(numvoie)+2, typvoie, libvoie), 'citycode': depcom, 'limit': '1'}, 'G')
+                    if ban_avant is not None and ban_apres is not None:
+                        if (ban_avant['properties']['type'] == 'housenumber' and
+                           ban_apres['properties']['type'] == 'housenumber' and
+                           ban_avant['properties']['score'] > 0.5 and
+                           ban_apres['properties']['score'] > score_min):
+                            source = ban_avant
+                            score = ban_avant['properties']['score']/2
+                            source['geometry']['coordinates'][0] = round((ban_avant['geometry']['coordinates'][0]+ban_apres['geometry']['coordinates'][0])/2,6)
+                            source['geometry']['coordinates'][1] = round((ban_avant['geometry']['coordinates'][1]+ban_apres['geometry']['coordinates'][1])/2,6)
+                            source['properties']['score'] = (ban_avant['properties']['score']+ban_apres['properties']['score'])/2
+                            source['properties']['type'] = 'interpolation'
+                            source['properties']['id'] = ''
+                            source['properties']['label'] = numvoie + ban_avant['properties']['label'][len(ban_avant['properties']['housenumber']):]
+
+            # on essaye sans l'indice de répétition (BIS, TER qui ne correspond pas ou qui manque en base)
+            if source is None and ban is None and indrep != '':
+                trace('supp. indrep BAN : %s %s %s' % (numvoie, typvoie, libvoie))
+                addok = geocode(addok_ban[ban_number], {'q': '%s %s %s' % (numvoie, typvoie, libvoie), 'citycode': depcom, 'limit': '1'}, 'G')
+                if addok is not None and addok['properties']['type'] == 'housenumber' and addok['properties']['score'] > score_min:
+                    addok['properties']['type'] = 'interpolation'
+                    source = addok
+                    trace('+ ban  L4G-indrep')
+
+            # pas trouvé ? on cherche une rue
+            if source is None and typvoie != '':
+                if ban_type == 'street' and ban_score > score_min:
+                    source = ban
+                    score = ban['properties']['score']
+
+            # pas trouvé ? on cherche sans numvoie
+            if source is None and numvoie != '':
+                trace('supp. numvoie : %s %s %s' % (numvoie, typvoie, libvoie))
+                addok = geocode(addok_ban[ban_number], {'q': '%s %s' % (typvoie, libvoie), 'citycode': depcom, 'limit': '1'}, 'G')
+                if addok is not None and addok['properties']['type'] == 'street' and addok['properties']['score'] > score_min:
+                    source = addok
+                    trace('+ ban  L4G-numvoie')
+
+            # toujours pas trouvé ? tout type accepté...
+            if source is None:
+                if ban_score > score_min:
+                    source = ban
+
+            # vraiment toujours pas trouvé comme adresse ?
+            # on cherche dans les POI OpenStreetMap...
+            if source is None:
+                # Mairies et Hôtels de Ville...
+                if ['MAIRIE','LA MAIRIE','HOTEL DE VILLE'].count(libvoie) > 0:
+                    poi = geocode(addok_poi, {'q': 'hotel de ville', 'poi': 'townhall', 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > score_min:
+                        source = poi
+                # Gares...
+                elif ['GARE', 'GARE SNCF', 'LA GARE'].count(libvoie) > 0:
+                    poi = geocode(addok_poi, {'q': 'gare', 'poi': 'station', 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > score_min:
+                        source = poi
+                # Centres commerciaux...
+                elif re.match(ccial, libvoie) is not None:
+                    poi = geocode(addok_poi, {'q': re.sub(ccial, '\1 Galerie Marchande', libvoie), 'poi': 'mall', 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > 0.5:
+                        source = poi
+                elif re.match(ccial,libvoie) is not None:
+                    poi = geocode(addok_poi, {'q': re.sub(ccial, '\1 Centre Commercial', libvoie), 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > 0.5:
+                        source = poi
+                # Aéroports et aérodromes...
+                elif re.match(r'(AEROPORT|AERODROME)', libvoie) is not None:
+                    poi = geocode(addok_poi, {'q': libvoie, 'poi': 'aerodrome', 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > score_min:
+                        source = poi
+                elif re.match(r'(AEROGARE|TERMINAL)', libvoie) is not None:
+                    poi = geocode(addok_poi, {'q': re.sub(r'(AEROGARE|TERMINAL)', '', libvoie)+' terminal', 'poi': 'terminal', 'citycode': depcom, 'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > score_min:
+                        source = poi
+
+                # recherche tout type de POI à partir du type et libellé de voie
+                if source is None:
+                    poi = geocode(addok_poi, {'q': typvoie+' '+libvoie,
+                                              'citycode': depcom,
+                                              'limit': '1'}, 'G')
+                    if poi is not None and poi['properties']['score'] > 0.7:
+                        source = poi
+
+                if source is not None:
+                    if source['properties']['poi'] != 'yes':
+                        source['properties']['type'] = source['properties']['type']+'.'+source['properties']['poi']
+                    print(json.dumps({'action': 'poi', 'adr_insee': depcom,
+                                      'adr_texte': libvoie, 'poi': source},
+                                     sort_keys=True))
+
+            if source is not None and score == 0:
+                score = source['properties']['score']
+
+            # on conserve le résultat dans le cache sqlite
+            if conn:
+                key = ('%s|%s|%s|%s' % (depcom, ligne4G, ligne4N, ligne4D))
+                cursor = conn.execute('INSERT INTO cache_addok VALUES (?,?,?)',
+                                      (key, marshal.dumps(source), score))
+
+        if source is None:
+            # attention latitude et longitude sont inversées dans le fichier
+            # CSV et donc la base sqlite
+            row = et+['', '', 0, '', '', '', '', '', '']
+            try:
+                row = et+[commune_insee[depcom]['lon'],
+                          commune_insee[depcom]['lat'],
+                          0, 'municipality', '', commune_insee[i], '', '', '']
+                if ligne4G.strip() != '':
+                    if typvoie == '' and ['CHEF LIEU', 'CHEF-LIEU',
+                                          'LE CHEF LIEU', 'LE CHEF-LIEU',
+                                          'BOURG', 'LE BOURG', 'AU BOURG',
+                                          'VILLAGE', 'AU VILLAGE',
+                                          'LE VILLAGE'].count(libvoie) > 0:
+                        stats['locality'] += 1
+                        ok += 1
+                    else:
+                        stats['municipality'] += 1
+                        print(json.dumps({'action': 'manque',
+                                          'siret': et[0]+et[1],
+                                          'adr_comm_insee': depcom,
+                                          'adr_texte': ligne4G.strip(),
+                                          'adr_norm': ligne4N.strip(),
+                                          'adr_decl': ligne4D.strip()},
+                                         sort_keys=True))
+                else:
+                    stats['vide'] += 1
+                    ok += 1
+            except:
+                pass
+            sirene_geo.writerow(row)
+        else:
+            ok += 1
+            if ['village', 'town', 'city'].count(source['properties']['type']) > 0:
+                source['properties']['type'] = 'municipality'
+            stats[re.sub(r'\..*$', '', source['properties']['type'])] += 1
+            sirene_geo.writerow(et+[source['geometry']['coordinates'][0],
+                                    source['geometry']['coordinates'][1],
+                                    round(source['properties']['score'], 2),
+                                    source['properties']['type'],
+                                    source['properties']['label'],
+                                    source['properties']['id'],
+                                    source['l4'] if 'l4' in source else '',
+                                    source['geo_l4'] if 'geo_l4' in source else '',
+                                    source['geo_l5'] if 'geo_l5' in source else ''])
+            if 'score' in source['properties']:
+                score_count = score_count + 1
+                score_total = score_total + source['properties']['score']
+                if score_count > 100:
+                    score_variance = score_variance + (source['properties']['score'] - score_total / score_count) ** 2
+
+        if total % 1000 == 0:
+            stats['geocode_cache'] = cache
+            stats['count'] = total
+            stats['geocode_count'] = geocode_count
+            if total>0:
+                stats['efficacite'] = round(100*ok/total, 2)
+            if score_count > 0:
+                stats['geocode_score_avg'] = score_total / score_count
+            if score_count > 101:
+                stats['geocode_score_variance'] = score_variance / (score_count-101)
+            print(json.dumps(stats, sort_keys=True))
+            if conn:
+                conn.commit()
+
+stats['geocode_cache'] = cache
+stats['count'] = total
+stats['geocode_count'] = geocode_count
+stats['action'] = 'final'
+if total>0:
+    stats['efficacite'] = round(100*ok/total, 2)
+if score_count > 0:
+    stats['geocode_score_avg'] = score_total / score_count
+if score_count > 101:
+    stats['geocode_score_variance'] = score_variance / (score_count-101)
+print(json.dumps(stats, sort_keys=True))
+if conn:
+    conn.commit()


### PR DESCRIPTION
Afin d'éviter que le DAG ne pousse des fichiers incomplets cette PR propose de rajouter des tests de cohérences sur les fichiers départements générés.

Les tests réutilisent les fichiers `stats.json` produits par le script `4b_geocode_stats.sh`.
Ils comparent les volumes et l'efficacité du géocodage avec celui du moins précédent pour s'assurer qu'aucun problème n'ai eu lieu.

J'en ai profité pour copier les fichiers qui étaient sur le serveur distant.

Dans un premier temps cette PR ne bloque pas le DAG en cas de problème remonté.
Je n'ai pas osé tester le DAG en entier.

Pour tester la nouvelle task depuis le remote:
```
cp /srv/sirene/data-sirene/2024-09/stats.json /srv/sirene/data-sirene/stats.json
/srv/sirene/venv/bin/python /srv/sirene/geocodage-sirene/4c_check_stats_coherence.py
rm /srv/sirene/data-sirene/stats.json
```