### PR TITLE
[DAG geocodage] Add mandatory tests and new schedule

### DIFF
--- a/data_processing/insee/sirene/geocodage/DAG-sirene-geocodage-etalab.py
+++ b/data_processing/insee/sirene/geocodage/DAG-sirene-geocodage-etalab.py
@@ -4,8 +4,7 @@ from airflow.contrib.operators.ssh_operator import SSHOperator
 
 with DAG(
     dag_id="data_processing_sirene_geocodage",
-    # Runs at 7:48 AM on the 1st, 5th, and 10th of each month
-    schedule_interval="48 7 1,5,10 * *",
+    schedule_interval="48 16 1,5,10 * *",
     start_date=datetime(2024, 8, 10),
     catchup=False,
     tags=["data_processing", "sirene", "geocodage", "etalab" "geocodage"],
@@ -147,6 +146,6 @@ with DAG(
     prepare_to_rsync.set_upstream(national_files_agregation)
     prepare_to_rsync.set_upstream(split_by_locality)
     check_stats_coherence.set_upstream(get_geocode_stats)
-    prepare_to_rsync.set_upstream(get_geocode_stats)
+    prepare_to_rsync.set_upstream(check_stats_coherence)
     rsync_to_files_data_gouv.set_upstream(prepare_to_rsync)
     mkdir_last_and_symbolic_links.set_upstream(rsync_to_files_data_gouv)

--- a/data_processing/insee/sirene/geocodage/README.md
+++ b/data_processing/insee/sirene/geocodage/README.md
@@ -6,7 +6,7 @@
 | -------- | -------- |
 | Fichier source     | `DAG-sirene-geocodage-etalab.py`     |
 | Description | DAG Airflow qui récupère les données de la base SIRENE publiées sur data.gouv.fr et lance un géocodage basé sur la BAL. Ce DAG dure plusieurs heures et dépose les fichiers sur files.data.gouv.fr/geo-sirene|
-| Fréquence de mise à jour |  Mensuel (les 1er, 5 et 10 du mois) |
+| Fréquence de mise à jour |  Mensuel (les 1er, 5 et 10 du mois) à 16:48 UTC le 1er, 5 et 10. Les données sources SIRENE étant généralement mises à jours dans la matinée |
 | Données sources | [JDD INSEE data.gouv.fr](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/) |
 | Données de sorties | [JDD Etalab data.gouv.fr](https://www.data.gouv.fr/fr/datasets/base-sirene-des-etablissements-siret-geolocalisee-avec-la-base-dadresse-nationale-ban/) |
 | Channel Mattermost d'information | ~startup-datagouv-dataeng |

--- a/data_processing/insee/sirene/geocodage/remote_files/4c_check_stats_coherence.py
+++ b/data_processing/insee/sirene/geocodage/remote_files/4c_check_stats_coherence.py
@@ -137,10 +137,7 @@ def check_stats_coherence(file_prev: str, file_next: str) -> None:
     else:
         print("Stats are coherent.")
 
-    # TODO: After running at least once in production
-    # Change the print code to:
-    # exit(error_code)
-    print(f"Error Code: {error_code}")
+    exit(error_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make coherence tests mandatory since they ran in December successfully.

Move the schedule to 16:48 UTC because SIRENE data is often updated in the morning. This help avoid working on obsolete data the 1st of the month.