### PR TITLE
[DAG metrics] Rename visit column in dataservices_total view

### DIFF
--- a/dgv/metrics/sql/create_tables.sql
+++ b/dgv/metrics/sql/create_tables.sql
@@ -324,7 +324,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS metric.dataservices_total AS
     SELECT
         MIN(__id) AS __id,
         dataservice_id,
-        SUM(nb_visit) AS visit_dataservice
+        SUM(nb_visit) AS visit
     FROM metric.visits_dataservices
     GROUP BY dataservice_id
 ;


### PR DESCRIPTION
Indeed, other models have column `visit` only if there is no ambiguity.

We may need to delete this materialized view for the change to take place?