### PR TITLE
Abstract datagouv interactions

### DIFF
--- a/utils/datagouv.py
+++ b/utils/datagouv.py
@@ -193,6 +193,9 @@ class Resource(BaseObject):
         )
         self.front_url = self.url.replace("api/1", "fr").replace("/resources", "/#/resources")
 
+    def dataset(self):
+        return Dataset(self.dataset_id, _client=self._client)
+
     @simple_connection_retry
     def check_if_more_recent_update(
         self,

--- a/utils/datagouv.py
+++ b/utils/datagouv.py
@@ -169,6 +169,12 @@ class Dataset(BaseObject):
         self.url = f"{_client.base_url}/api/1/datasets/{id}/"
         self.front_url = self.url.replace("api/1", "fr")
 
+    def resources(self):
+        return [
+            Resource(id=r["id"], dataset_id=self.id, _client=self._client)
+            for r in self.get_metadata()["resources"]
+        ]
+
 
 class Resource(BaseObject):
     def __init__(

--- a/utils/datagouv.py
+++ b/utils/datagouv.py
@@ -213,12 +213,12 @@ class DatasetCreator:
         self._client = _client
 
     @simple_connection_retry
-    def create(self, payload: dict) -> requests.Response:
+    def create(self, payload: dict) -> Dataset:
         assert_auth(self._client)
         logging.info(f"Creating dataset '{payload['title']}'")
         r = self._client.session.post(f"{self._client.base_url}/api/1/datasets/", json=payload)
         r.raise_for_status()
-        return r
+        return Dataset(r.json()["id"], _client=self._client)
 
 
 class ResourceCreator:
@@ -232,7 +232,7 @@ class ResourceCreator:
         dataset_id: str,
         payload: dict,
         is_communautary: bool = False,
-    ) -> requests.Response:
+    ) -> Resource:
         if is_communautary:
             url = f"{self._client.base_url}/api/1/datasets/community_resources"
             payload["dataset"] = {"class": "Dataset", "id": dataset_id}
@@ -243,7 +243,7 @@ class ResourceCreator:
             payload.update({"filetype": "remote"})
         r = self._client.session.post(url, json=payload)
         r.raise_for_status()
-        return r
+        return Resource(r.json()["id"], _client=self._client)
 
     @simple_connection_retry
     def create_static(
@@ -252,7 +252,7 @@ class ResourceCreator:
         dataset_id: str,
         payload: dict,
         is_communautary: bool = False,
-    ) -> requests.Response:
+    ) -> Resource:
         if is_communautary:
             url = f"{self._client.base_url}/api/1/datasets/community_resources"
             payload["dataset"] = {"class": "Dataset", "id": dataset_id}
@@ -268,7 +268,7 @@ class ResourceCreator:
         resource_id = r.json()['id']
         logging.info(f"Resource was given this id: {resource_id}")
         r = Resource(resource_id=resource_id, dataset_id=dataset_id).update_metadata(payload=payload)
-        return r
+        return Resource(resource_id, _client=self._client)
 
 
 prod_client = Client(api_key=DATAGOUV_SECRET_API_KEY)

--- a/utils/datagouv.py
+++ b/utils/datagouv.py
@@ -89,12 +89,12 @@ class Client:
             self._authenticated = True
             self.session.headers.update({"X-API-KEY": api_key})
 
-    def Resource(self, id: str | None = None, **kwargs):
+    def resource(self, id: str | None = None, **kwargs):
         if id:
             return Resource(id, _client=self, **kwargs)
         return ResourceCreator(_client=self)
 
-    def Dataset(self, id: str | None = None):
+    def dataset(self, id: str | None = None):
         if id:
             return Dataset(id, _client=self)
         return DatasetCreator(_client=self)


### PR DESCRIPTION
New syntaxes:
- client:
```python
prod_client = Client(api_key=DATAGOUV_SECRET_API_KEY)
demo_client = Client(environment="demo", api_key=DEMO_DATAGOUV_SECRET_API_KEY)
visiter_client = Client()  # this one can only get data
```
- common to datasets and resources:
```python
client.Dataset(dataset_id).front_url
client.Dataset(dataset_id).get_metadata()
client.Resource(resource_id, dataset_id).get_metadata()  # dataset_id is optional, retrieved if not speficied
client.Dataset(dataset_id).update_metadata({"title": "New title"})
client.Dataset(dataset_id).delete()
client.Dataset(dataset_id).update_extras(payload)
client.Dataset(dataset_id).delete_extras(payload)
```
- dataset related:
```python
client.Dataset().create(payload)
```
- resource related:
```python
client.Resource().create_remote(
    dataset_id=dataset_id,
    payload={
        'title': 'Mon titre',
        'description': 'Ma description',
        'url': 'https://url.to/ressource.csv',
        'type': 'main',
        'format': 'csv',
    },
)
client.Resource().create_static(
    file_to_upload=MyFile,  # currently a File instance from utils/filesystem.py
    dataset_id=dataset_id,
    payload={
        'title': 'Mon titre',
        'description': 'Ma description',
        'type': 'main',
        'format': 'csv',
    },
)
```
Ideally, I'd like the creation functions to be class or static methods, because it feels weird to have to instanciate a `Dataset` or `Resource` to be able to create one, but I have not managed to find a way to do that, as both `DatasetCreator` and `ResourceCreator` need to be given the instanciated client.
An other syntax could be:
```python
client.create_dataset(...)
client.create_static_resource(...)
```