### PR TITLE
[DAGs SIREN publication] refactor: smarter change detection

### DIFF
--- a/data_processing/insee/sirene/stock/DAG-sirene-geolocalisation-insee.py
+++ b/data_processing/insee/sirene/stock/DAG-sirene-geolocalisation-insee.py
@@ -63,6 +63,7 @@ with DAG(
         templates_dict={
             "resource_file": "resources_geolocalisation_to_download.json",
             "day_file": "21",
+            "tmp_dir": TMP_FOLDER,
         },
         python_callable=update_dataset_data_gouv,
     )

--- a/data_processing/insee/sirene/stock/DAG-sirene-geolocalisation-insee.py
+++ b/data_processing/insee/sirene/stock/DAG-sirene-geolocalisation-insee.py
@@ -7,17 +7,15 @@ from datagouvfr_data_pipelines.config import (
     AIRFLOW_DAG_TMP,
 )
 from datagouvfr_data_pipelines.data_processing.insee.sirene.stock.task_functions import (
+    check_if_already_processed,
     get_files,
-    upload_files_minio,
-    compare_minio_files,
-    move_new_files_to_latest,
     publish_file_minio,
     update_dataset_data_gouv,
     publish_mattermost,
 )
 
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}sirene_geolocalisation_insee/"
-MINIO_BASE_PATH = "insee/sirene/sirene_geolocalisation_insee/"
+MINIO_BASE_PATH = "siren/geoloc/"
 
 with DAG(
     dag_id="data_processing_sirene_geolocalisation",
@@ -33,6 +31,14 @@ with DAG(
         bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER}",
     )
 
+    check_if_already_processed = ShortCircuitOperator(
+        task_id="check_if_already_processed",
+        templates_dict={
+            "minio_path": MINIO_BASE_PATH,
+        },
+        python_callable=check_if_already_processed,
+    )
+
     get_files = PythonOperator(
         task_id="get_files",
         templates_dict={
@@ -42,42 +48,12 @@ with DAG(
         python_callable=get_files,
     )
 
-    upload_new_files_minio = PythonOperator(
-        task_id="upload_new_files_minio",
-        templates_dict={
-            "tmp_dir": TMP_FOLDER,
-            "minio_path": MINIO_BASE_PATH + "new/",
-            "resource_file": "resources_geolocalisation_to_download.json",
-        },
-        python_callable=upload_files_minio,
-    )
-
-    compare_minio_files = ShortCircuitOperator(
-        task_id="compare_minio_files",
-        templates_dict={
-            "minio_path_new": MINIO_BASE_PATH + "new/",
-            "minio_path_latest": MINIO_BASE_PATH + "latest/",
-            "resource_file": "resources_geolocalisation_to_download.json",
-        },
-        python_callable=compare_minio_files,
-    )
-
-    move_new_files_to_latest = PythonOperator(
-        task_id="move_new_files_to_latest",
-        templates_dict={
-            "minio_latest_path": MINIO_BASE_PATH + "latest/",
-            "minio_new_path": MINIO_BASE_PATH + "new/",
-            "resource_file": "resources_geolocalisation_to_download.json",
-        },
-        python_callable=move_new_files_to_latest,
-    )
-
     publish_file_minio = PythonOperator(
         task_id="publish_file_minio",
         templates_dict={
             "tmp_dir": TMP_FOLDER,
             "resource_file": "resources_geolocalisation_to_download.json",
-            "minio_path": "siren/geoloc/",
+            "minio_path": MINIO_BASE_PATH,
         },
         python_callable=publish_file_minio,
     )
@@ -103,11 +79,9 @@ with DAG(
         trigger_rule="none_failed",
     )
 
-    get_files.set_upstream(clean_previous_outputs)
-    upload_new_files_minio.set_upstream(get_files)
-    compare_minio_files.set_upstream(upload_new_files_minio)
-    move_new_files_to_latest.set_upstream(compare_minio_files)
-    publish_file_minio.set_upstream(move_new_files_to_latest)
+    check_if_already_processed.set_upstream(clean_previous_outputs)
+    get_files.set_upstream(check_if_already_processed)
+    publish_file_minio.set_upstream(get_files)
     update_dataset_data_gouv.set_upstream(publish_file_minio)
     publish_mattermost_geoloc.set_upstream(update_dataset_data_gouv)
     clean_up.set_upstream(publish_mattermost_geoloc)

--- a/data_processing/insee/sirene/stock/DAG-sirene-publication-insee.py
+++ b/data_processing/insee/sirene/stock/DAG-sirene-publication-insee.py
@@ -64,6 +64,7 @@ with DAG(
         templates_dict={
             "resource_file": "resources_to_download.json",
             "day_file": "01",
+            "tmp_dir": TMP_FOLDER,
         },
         python_callable=update_dataset_data_gouv,
     )

--- a/data_processing/insee/sirene/stock/DAG-sirene-publication-insee.py
+++ b/data_processing/insee/sirene/stock/DAG-sirene-publication-insee.py
@@ -5,10 +5,8 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 from datagouvfr_data_pipelines.data_processing.insee.sirene.stock.task_functions import (
+    check_if_already_processed,
     get_files,
-    upload_files_minio,
-    compare_minio_files,
-    move_new_files_to_latest,
     publish_file_minio,
     update_dataset_data_gouv,
     publish_mattermost,
@@ -18,7 +16,7 @@ from datagouvfr_data_pipelines.config import (
 )
 
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}sirene_publication/"
-MINIO_BASE_PATH = "insee/sirene/sirene_publication/"
+MINIO_BASE_PATH = "siren/stock/"
 
 with DAG(
     dag_id="data_processing_sirene_publication",
@@ -34,6 +32,14 @@ with DAG(
         bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER}",
     )
 
+    check_if_already_processed = ShortCircuitOperator(
+        task_id="check_if_already_processed",
+        templates_dict={
+            "minio_path": MINIO_BASE_PATH,
+        },
+        python_callable=check_if_already_processed,
+    )
+
     get_files = PythonOperator(
         task_id="get_files",
         templates_dict={
@@ -43,42 +49,12 @@ with DAG(
         python_callable=get_files,
     )
 
-    upload_new_files_minio = PythonOperator(
-        task_id="upload_new_files_minio",
-        templates_dict={
-            "tmp_dir": TMP_FOLDER,
-            "minio_path": MINIO_BASE_PATH + "new/",
-            "resource_file": "resources_to_download.json",
-        },
-        python_callable=upload_files_minio,
-    )
-
-    compare_minio_files = ShortCircuitOperator(
-        task_id="compare_minio_files",
-        templates_dict={
-            "minio_path_new": MINIO_BASE_PATH + "new/",
-            "minio_path_latest": MINIO_BASE_PATH + "latest/",
-            "resource_file": "resources_to_download.json",
-        },
-        python_callable=compare_minio_files,
-    )
-
-    move_new_files_to_latest = PythonOperator(
-        task_id="move_new_files_to_latest",
-        templates_dict={
-            "minio_latest_path": MINIO_BASE_PATH + "latest/",
-            "minio_new_path": MINIO_BASE_PATH + "new/",
-            "resource_file": "resources_to_download.json",
-        },
-        python_callable=move_new_files_to_latest,
-    )
-
     publish_file_minio = PythonOperator(
         task_id="publish_file_minio",
         templates_dict={
             "tmp_dir": TMP_FOLDER,
             "resource_file": "resources_to_download.json",
-            "minio_path": "siren/stock/",
+            "minio_path": MINIO_BASE_PATH,
         },
         python_callable=publish_file_minio,
     )
@@ -109,11 +85,9 @@ with DAG(
         trigger_dag_id="data_processing_sirene_geocodage",
     )
 
-    get_files.set_upstream(clean_previous_outputs)
-    upload_new_files_minio.set_upstream(get_files)
-    compare_minio_files.set_upstream(upload_new_files_minio)
-    move_new_files_to_latest.set_upstream(compare_minio_files)
-    publish_file_minio.set_upstream(move_new_files_to_latest)
+    check_if_already_processed.set_upstream(clean_previous_outputs)
+    get_files.set_upstream(check_if_already_processed)
+    publish_file_minio.set_upstream(get_files)
     update_dataset_data_gouv.set_upstream(publish_file_minio)
     publish_mattermost.set_upstream(update_dataset_data_gouv)
     clean_up.set_upstream(publish_mattermost)


### PR DESCRIPTION
Cuts the whole process: before downloading anything we check if the file of the current months have been retrieved, and if so we don't go any further
We'll finally get rid of the fil comparisons and the duplicates stored in the `data-pipeline` bucket