### PR TITLE
Fix geocodage locality split

### DIFF
--- a/data_processing/insee/sirene/geocodage/scripts/1_download_last_sirene_batch.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/1_download_last_sirene_batch.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 env=$1
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     data_path="/srv/sirene/data-sirene"
 else
     data_path="/srv/sirene/data-sirene/$env"

--- a/data_processing/insee/sirene/geocodage/scripts/2_split_departments_files.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/2_split_departments_files.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 env=$1
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     cd "/srv/sirene/data-sirene"
 else
     cd "/srv/sirene/data-sirene/$env"

--- a/data_processing/insee/sirene/geocodage/scripts/3_geocoding_by_increasing_size.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/3_geocoding_by_increasing_size.sh
@@ -2,7 +2,7 @@
 env=$1
 script_path=$2
 set -e
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     data_path="/srv/sirene/data-sirene"
 else
     data_path="/srv/sirene/data-sirene/$env"

--- a/data_processing/insee/sirene/geocodage/scripts/4a_split_by_locality.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/4a_split_by_locality.sh
@@ -7,5 +7,5 @@ if [ -z "$env" ] || [ "$env" = "prod" ]; then
 else
     cd /srv/sirene/data-sirene/$env/data
 fi
-ls -1 geo_siret_*.csv.gz | parallel sh $script_path/communes_split.sh {} "$env"
+ls -1 geo_siret_*.csv.gz | parallel sh $script_path/communes_split.sh {} $env
 echo "Split OK!"

--- a/data_processing/insee/sirene/geocodage/scripts/4a_split_by_locality.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/4a_split_by_locality.sh
@@ -2,7 +2,7 @@
 env=$1
 script_path=$2
 echo "Splitting by locality"
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     cd /srv/sirene/data-sirene/data
 else
     cd /srv/sirene/data-sirene/$env/data

--- a/data_processing/insee/sirene/geocodage/scripts/4b_geocode_stats.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/4b_geocode_stats.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 env=$1
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     cd /srv/sirene/data-sirene
 else
     cd /srv/sirene/data-sirene/$env

--- a/data_processing/insee/sirene/geocodage/scripts/communes_split.sh
+++ b/data_processing/insee/sirene/geocodage/scripts/communes_split.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 env=$2
-if [ -z "$env" ] || [ "$env" == "prod" ]; then
+if [ -z "$env" ] || [ "$env" = "prod" ]; then
     data_path="/srv/sirene/data-sirene"
 else
     data_path="/srv/sirene/data-sirene/$env"


### PR DESCRIPTION
<img width="690" height="225" alt="image" src="https://github.com/user-attachments/assets/dc861b2d-66d7-40d9-9d8e-aefcc015ea3a" />

PR to solve missing communes split in https://files.data.gouv.fr/geo-sirene/2025-08/communes/

It was tested on dev and the fix seems to work:

<img width="408" height="358" alt="image" src="https://github.com/user-attachments/assets/73907575-141d-4e00-9401-17869ac94535" />
