### PR TITLE
[DGV METRICS] Temporary increase metrics timeout

### DIFF
--- a/dgv/metrics/dag.py
+++ b/dgv/metrics/dag.py
@@ -35,7 +35,8 @@ with DAG(
     schedule_interval="15 6 * * *",
     start_date=datetime(2024, 8, 10),
     catchup=False,
-    dagrun_timeout=timedelta(minutes=60 * 8),
+    dagrun_timeout=timedelta(minutes=60 * 24),
+    max_active_runs=1,
     tags=["dgv", "metrics"],
     default_args=default_args,
 ) as dag:


### PR DESCRIPTION
Afin de pouvoir process tous les logs de juillet et aout.

PR pour revert une fois fini : https://github.com/datagouv/datagouvfr_data_pipelines/pull/558