### PR TITLE
[DGV.METRICS] improve aggregation task performance for multi-days processing

### DIFF
--- a/dgv/metrics/task.py
+++ b/dgv/metrics/task.py
@@ -192,7 +192,8 @@ def visit_postgres_duplication_safety(ti) -> None:
 
 def save_metrics_to_postgres() -> None:
     for obj_config in config.logs_config:
-        for lf in glob.glob(f"{OUTPUT_FOLDER}??????????_{obj_config.type}.csv"):
+        # Looking for files such as 2025-09-24_resources.csv
+        for lf in glob.glob(f"{OUTPUT_FOLDER}????-??-??_{obj_config.type}.csv"):
             if "-id-" not in lf and "-static-" not in lf:
                 pgclient.copy_file(
                     file=File(

--- a/dgv/metrics/task.py
+++ b/dgv/metrics/task.py
@@ -137,18 +137,18 @@ def aggregate_log(ti) -> None:
 
     remove_files_from_directory(OUTPUT_FOLDER)
 
-    for log_date in dates_to_process:
-        # isoformat_log_date = datetime.strptime(log_date, "%d%m%Y").date().isoformat()
-        for obj_config in config.logs_config:
+    for obj_config in config.logs_config:
+        df_catalog = pd.read_csv(
+            f"{TMP_FOLDER}{obj_config.catalog_destination_name}",
+            dtype="string",
+            sep=";",
+            usecols=list(obj_config.catalog_columns.keys()),
+        )
+        for log_date in dates_to_process:
+            isoformat_log_date = datetime.strptime(log_date, "%d%m%Y").date().isoformat()
             logging.info(f"Aggregating {obj_config.type} objects...")
-            df_catalog = pd.read_csv(
-                f"{TMP_FOLDER}{obj_config.catalog_destination_name}",
-                dtype="string",
-                sep=";",
-                usecols=list(obj_config.catalog_columns.keys()),
-            )
             df = pd.read_csv(
-                f"{FOUND_FOLDER}{obj_config.type}_found.csv",
+                f"{FOUND_FOLDER}{isoformat_log_date}_{obj_config.type}_found.csv",
                 dtype="string",
                 sep=";",
             )
@@ -158,11 +158,11 @@ def aggregate_log(ti) -> None:
                 df_catalog,
                 obj_config,
                 config,
-                f"{OUTPUT_FOLDER}{obj_config.type}-{log_date}.csv",
+                f"{OUTPUT_FOLDER}{isoformat_log_date}_{obj_config.type}.csv",
             )
             dates_processed = get_unique_list(dates_processed, processed_dates)
             logging.info(
-                f"> Output saved in {obj_config.type}-{log_date}.csv ({n_rows} rows)."
+                f"> Output saved in {isoformat_log_date}_{obj_config.type}.csv ({n_rows} rows)."
                 f" With columns: {obj_config.output_columns}"
             )
 
@@ -192,7 +192,7 @@ def visit_postgres_duplication_safety(ti) -> None:
 
 def save_metrics_to_postgres() -> None:
     for obj_config in config.logs_config:
-        for lf in glob.glob(f"{OUTPUT_FOLDER}{obj_config.type}-*"):
+        for lf in glob.glob(f"{OUTPUT_FOLDER}??????????_{obj_config.type}.csv"):
             if "-id-" not in lf and "-static-" not in lf:
                 pgclient.copy_file(
                     file=File(

--- a/dgv/metrics/task_functions.py
+++ b/dgv/metrics/task_functions.py
@@ -194,6 +194,13 @@ def aggregate_metrics(
         catalog_dict: dict[str, str] = defaultdict()
         static_uri = "https://static.data.gouv.fr/resources/"
 
+        # A few resource_id are common to multiple datasets
+        # Deduplication priority is : "dataset.archived" as False otherwise keep the last one created
+        df_catalog = (
+            df_catalog.sort_values(by=["dataset.archived", "created_at"], ascending=[True, False])
+            .drop_duplicates(subset=["id"], keep="first")
+        )
+
         # Resource catalog has no slug column but static
         # URLs starting with https://static.data.gouv.fr/resources/$SLUG
         # Using a resource ID will trigger a redirect to its static URL so we want:
@@ -206,13 +213,8 @@ def aggregate_metrics(
         catalog_dict.update(df_slugs.set_index("slug")["id"].to_dict())
 
         # 2. All the IDs that don't have any static URL
-        #  Note: a few resource_id are common to multiple datasets
-        #  They need to be deduplicated with a priority to
-        #  "dataset.archived" as False otherwise keep the last one created
         df_ids = (
             df_catalog.loc[lambda df: ~df["url"].str.contains(static_uri)]
-            .sort_values(by=["dataset.archived", "created_at"], ascending=[True, False])
-            .drop_duplicates(subset=["id"], keep="first")
             .filter(items=["id"])
         )
         catalog_dict.update({id: id for id in df_ids["id"].to_list()})

--- a/dgv/metrics/task_functions.py
+++ b/dgv/metrics/task_functions.py
@@ -40,7 +40,7 @@ def save_log_infos_to_csv(
             and the values are lists of objects of that type.
     """
     for type, list_obj in logs_info_per_type.items():
-        destination_file = f"{output_path}{type}_found.csv"
+        destination_file = f"{output_path}{date}_{type}_found.csv"
         save_list_of_dict_to_csv(list_obj, destination_file)
 
 


### PR DESCRIPTION
Load each catalog only once.
Use the same date-type-*.csv name format for all CSV files.
Save the processing results daily chunk so it can be reused by the aggregation logic.
Stop aggregating the same files multiple times.
Fix a few old resources still duplicated because of multiple entries in the catalog.

PR tested in local.