### PR TITLE
[DVG METRICS] Fix static resources metrics

### DIFF
--- a/dgv/metrics/config.py
+++ b/dgv/metrics/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 import yaml
 
 
@@ -13,6 +14,7 @@ class DataGouvLog:
         database_excluded_column: list[str],
         static_segments: list[str] = [],
         additional_patterns: dict[str, str] | None = None,
+        ** kwargs : Any,
     ) -> None:
         self.type = type
         self.catalog_columns = catalog_columns
@@ -63,7 +65,7 @@ class MetricsConfig:
             self.all_segments = self.api_segments + self.web_segments
             self.logs_config = [
                 DataGouvLog(
-                    segments=self.all_segments,
+                    segments=getattr(self, obj.get("all_segments", "all_segments")),  # all_segments may be overwritten in obj config
                     global_pattern=config_data["global_pattern"],
                     database_excluded_column=config_data["database_excluded_column"],
                     **obj,

--- a/dgv/metrics/config.yaml
+++ b/dgv/metrics/config.yaml
@@ -30,6 +30,7 @@ datagouv_logs:
       dataset.organization_id: organization_id
       dataset.archived: archived
       created_at: created_at
+    all_segments: api_segments
     static_segments:
       - "static_resource"
     additional_patterns:


### PR DESCRIPTION
Ignore web segments in the case of resources.
Indeed, log lines were matching the new "no prefix" web segment pattern instead of the static one.

Example of log
```
2025-09-25T09:47:43.073809+02:00 slb-XX haproxy[992702]: X.X.X.X:9722 [25/Sep/2025:09:47:43.020] DATAGOUVFR_RGS~ DATAGOUVFR_NEWINFRA/server-XX 0/0/2/50/+52 200 +1213 - - --NN 392/233/3/3/0 0/0 "GET https://static.data.gouv.fr/resources/donnees-agregees-du-referentiel-national-des-coproprietes-coproff/20250918-102625/dictionnaire-tableau-synthetique-coproff-reg-2024.csv HTTP/2.0"
```