### PR TITLE
feat(simplifions): retry on errors

### DIFF
--- a/verticales/simplifions/grist_v2_manager.py
+++ b/verticales/simplifions/grist_v2_manager.py
@@ -3,6 +3,7 @@ from datagouvfr_data_pipelines.config import (
     GRIST_API_URL,
     SECRET_GRIST_API_KEY,
 )
+from datagouvfr_data_pipelines.utils.retry import simple_connection_retry
 
 GRIST_DOC_ID = "ofSVjCSAnMb6SGZSb7GGrv"
 GRIST_WORKSPACE_ID = 51287
@@ -13,6 +14,7 @@ class GristV2Manager:
         pass
 
     @staticmethod
+    @simple_connection_retry
     def _request_grist_table(table_id: str, filter: str | None = None) -> list[dict]:
         r = requests.get(
             GRIST_API_URL + f"docs/{GRIST_DOC_ID}/tables/{table_id}/records",
@@ -27,6 +29,7 @@ class GristV2Manager:
         return r.json()["records"]
 
     @staticmethod
+    @simple_connection_retry
     def _request_all_tables() -> dict:
         r = requests.get(
             GRIST_API_URL + f"docs/{GRIST_DOC_ID}/tables",
@@ -40,6 +43,7 @@ class GristV2Manager:
         return r.json()["tables"]
 
     @staticmethod
+    @simple_connection_retry
     def _request_table_columns(table_id: str) -> dict:
         r = requests.get(
             GRIST_API_URL + f"docs/{GRIST_DOC_ID}/tables/{table_id}/columns",
@@ -53,6 +57,7 @@ class GristV2Manager:
         return r.json()["columns"]
 
     @staticmethod
+    @simple_connection_retry
     def _request_table_records(
         table_id: str, filter: str | None = None, document_id: str = GRIST_DOC_ID
     ) -> list[dict]:
@@ -69,6 +74,7 @@ class GristV2Manager:
         return r.json()["records"]
 
     @staticmethod
+    @simple_connection_retry
     def _copy_document(document_name: str, as_template: bool = False) -> dict:
         r = requests.post(
             GRIST_API_URL + f"docs/{GRIST_DOC_ID}/copy",
@@ -87,6 +93,7 @@ class GristV2Manager:
         return r.json()
 
     @staticmethod
+    @simple_connection_retry
     def _list_workspace_documents() -> dict:
         r = requests.get(
             GRIST_API_URL + f"workspaces/{GRIST_WORKSPACE_ID}",
@@ -100,6 +107,7 @@ class GristV2Manager:
         return r.json()["docs"]
 
     @staticmethod
+    @simple_connection_retry
     def _delete_document(document_id: str) -> dict:
         r = requests.delete(
             GRIST_API_URL + f"docs/{document_id}",

--- a/verticales/simplifions/topics_api.py
+++ b/verticales/simplifions/topics_api.py
@@ -3,6 +3,7 @@ import logging
 import requests
 from datagouv import Client
 from datagouvfr_data_pipelines.utils.datagouv import local_client
+from datagouvfr_data_pipelines.utils.retry import simple_connection_retry
 
 
 class TopicsAPI:
@@ -17,6 +18,7 @@ class TopicsAPI:
     def _topic_url(self, topic_id: str) -> str:
         return f"{self.resource_url}/{topic_id}/"
 
+    @simple_connection_retry
     def create_topic(self, topic_data: dict):
         url = self.resource_url
         r = requests.post(
@@ -28,6 +30,7 @@ class TopicsAPI:
         logging.info(f"Created topic {topic_data['name']}")
         return r
 
+    @simple_connection_retry
     def delete_topic(self, topic_id: str):
         url = self._topic_url(topic_id)
         r = requests.delete(
@@ -38,6 +41,7 @@ class TopicsAPI:
         logging.info(f"Deleted topic at {url}")
         return r
 
+    @simple_connection_retry
     def update_topic_by_id(self, topic_id: str, topic_data: dict):
         url = self._topic_url(topic_id)
         r = requests.put(
@@ -50,6 +54,7 @@ class TopicsAPI:
         logging.info(f"Updated topic {topic_data.get('name')} at {url}")
         return r
 
+    @simple_connection_retry
     def get_all_topics_for_tag(self, tag: str) -> list[dict]:
         return local_client.get_all_from_api_query(
             f"{self.resource_url}/?tag={tag}&include_private=true",


### PR DESCRIPTION
Retry on basically all network requests for simplifions. Will hopefully reduce the number of failed jobs when grist or data.gouv.fr is down.