### PR TITLE
feat(simplifions): Mots_clefs as Topic.tags

### DIFF
--- a/verticales/simplifions/task_functions.py
+++ b/verticales/simplifions/task_functions.py
@@ -134,6 +134,7 @@ def update_topics_v2(client=None, **context):
                 topic_tags
                 + [f"{tag}-{grist_id_str}"]
                 + topics_manager._generated_search_tags(grist_row)
+                + topics_manager._keyword_tags(grist_row)
             )
 
             topic_data = {

--- a/verticales/simplifions/tests/conftest.py
+++ b/verticales/simplifions/tests/conftest.py
@@ -13,6 +13,26 @@ repo_root = Path(__file__).parent.parent.parent.parent
 simplifions_dir = repo_root / "verticales" / "simplifions"
 sys.path.insert(0, str(simplifions_dir))
 
+# Mock airflow since it is not installed in the test environment
+airflow_mock = types.ModuleType("airflow")
+airflow_decorators_mock = types.ModuleType("airflow.decorators")
+
+
+def _task_passthrough(fn=None, **kwargs):
+    """Passthrough decorator replacing @task() from airflow."""
+    if fn is not None:
+        return fn
+
+    def decorator(f):
+        return f
+
+    return decorator
+
+
+airflow_decorators_mock.task = _task_passthrough
+sys.modules["airflow"] = airflow_mock
+sys.modules["airflow.decorators"] = airflow_decorators_mock
+
 # Create all necessary packages to satisfy the datagouvfr_data_pipelines imports
 packages = [
     ("datagouvfr_data_pipelines", repo_root),

--- a/verticales/simplifions/tests/test_topics_v2_manager.py
+++ b/verticales/simplifions/tests/test_topics_v2_manager.py
@@ -137,4 +137,26 @@ class TestTopicsAreSimilarSoWeCanSkipUpdate:
         )
 
 
+class TestKeywordTags:
+    def test_with_keywords(self, topics_manager):
+        grist_row = {"id": 1, "fields": {"Mots_clefs": ["api", "identité"]}}
+        assert topics_manager._keyword_tags(grist_row) == ["api", "identité"]
+
+    def test_with_single_keyword(self, topics_manager):
+        grist_row = {"id": 1, "fields": {"Mots_clefs": "api"}}
+        assert topics_manager._keyword_tags(grist_row) == ["api"]
+
+    def test_with_empty_list(self, topics_manager):
+        grist_row = {"id": 1, "fields": {"Mots_clefs": []}}
+        assert topics_manager._keyword_tags(grist_row) == []
+
+    def test_with_none(self, topics_manager):
+        grist_row = {"id": 1, "fields": {"Mots_clefs": None}}
+        assert topics_manager._keyword_tags(grist_row) == []
+
+    def test_with_missing_field(self, topics_manager):
+        grist_row = {"id": 1, "fields": {}}
+        assert topics_manager._keyword_tags(grist_row) == []
+
+
 # Tests for moved update_topics method are now in test_task_functions.py

--- a/verticales/simplifions/topics_v2_manager.py
+++ b/verticales/simplifions/topics_v2_manager.py
@@ -73,6 +73,14 @@ class TopicsV2Manager:
         # deduplicate the list
         return list(set(tags))
 
+    def _keyword_tags(self, grist_row: GristRow) -> list[str]:
+        keywords = grist_row["fields"].get("Mots_clefs")
+        if not keywords:
+            return []
+        if not isinstance(keywords, list):
+            keywords = [keywords]
+        return [kw for kw in keywords if kw]
+
     def _topics_are_similar_so_we_can_skip_update(
         self, old_topic: dict, new_topic: dict
     ) -> bool:


### PR DESCRIPTION
- Inject `Mots_clefs` column from Grist into `Topic.tags`
- Fix tests for Airflow 3 #628 

Related https://github.com/opendatateam/udata-front-kit/pull/1078