### PR TITLE
chore: correcting meta and maintenance DAGs for Airflow3

### DIFF
--- a/maintenance/dag_clean_logs_and_runs.py
+++ b/maintenance/dag_clean_logs_and_runs.py
@@ -5,13 +5,14 @@ from datetime import datetime, timedelta, timezone
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.models import DagRun
-from airflow.settings import Session
+from airflow_client.client.api import dag_run_api
+
 from datagouvfr_data_pipelines.config import (
     AIRFLOW_DAG_HOME,
     AIRFLOW_ENV,
 )
 from datagouvfr_data_pipelines.utils.tchap import send_message
+from datagouvfr_data_pipelines.utils.airflow import AirflowAPI
 
 nb_days_to_keep = 60
 
@@ -66,28 +67,21 @@ def delete_old_runs():
     """
     Query and delete runs older than the threshold date (2 months ago).
     """
+
     oldest_run_date = datetime.now(tz=timezone.utc) - timedelta(days=nb_days_to_keep)
 
-    # Create a session to interact with the metadata database
-    session = Session()
-
-    try:
-        all_runs = session.query(DagRun).all()
-        idx = 0
-        for run in all_runs:
-            if run.end_date is None or run.end_date > oldest_run_date:
-                continue
-            idx += 1
-            logging.info(f"Deleting run: dag_id={run.dag_id}, end_date={run.end_date}")
-            session.delete(run)
-            if idx % 50 == 0:
-                session.commit()
-        session.commit()
-    except Exception as e:
-        logging.error(f"Error deleting old runs: {str(e)}")
-        session.rollback()
-    finally:
-        session.close()
+    with AirflowAPI(conn_name="airflow").client as client:
+        try:
+            api = dag_run_api.DagRunApi(client)
+            runs = api.get_dag_runs(
+                dag_id="~", end_date_lte=oldest_run_date
+            )  # All DAGs run older than the threshold
+            for run in runs.dag_runs:
+                dag_id = run.dag_id
+                logging.info(f"Deleting run: dag_id={dag_id}, end_date={run.end_date}")
+                api.delete_dag_run(dag_id=dag_id, dag_run_id=run.dag_run_id)
+        except Exception as e:
+            logging.error(f"Error deleting old runs: {str(e)}")
 
 
 @task()

--- a/maintenance/dag_clean_logs_and_runs.py
+++ b/maintenance/dag_clean_logs_and_runs.py
@@ -14,6 +14,7 @@ from datagouvfr_data_pipelines.config import (
 from datagouvfr_data_pipelines.utils.tchap import send_message
 from datagouvfr_data_pipelines.utils.airflow import AirflowAPI
 
+CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 nb_days_to_keep = 60
 
 
@@ -70,7 +71,7 @@ def delete_old_runs():
 
     oldest_run_date = datetime.now(tz=timezone.utc) - timedelta(days=nb_days_to_keep)
 
-    with AirflowAPI(conn_name="airflow").client as client:
+    with AirflowAPI(conn_name=CONN_NAME).client as client:
         try:
             api = dag_run_api.DagRunApi(client)
             runs = api.get_dag_runs(

--- a/meta/config.json
+++ b/meta/config.json
@@ -36,7 +36,6 @@
     "schema_consolidation": true,
     "irve_consolidation": true,
     "maintenance_clean_logs_and_runs": true,
-    "meta_dag": true,
     "schema_recommendations": true,
     "schema_website_publication": true,
     "verticale_culture": true,

--- a/meta/config.json
+++ b/meta/config.json
@@ -36,8 +36,12 @@
     "schema_consolidation": true,
     "irve_consolidation": true,
     "maintenance_clean_logs_and_runs": true,
+    "meta_dag": true,
     "schema_recommendations": true,
     "schema_website_publication": true,
     "verticale_culture": true,
-    "verticale_simplifions*": ["valentin", "alexandre"]
+    "verticale_simplifions*": [
+        "valentin",
+        "alexandre"
+    ]
 }

--- a/meta/dag.py
+++ b/meta/dag.py
@@ -4,6 +4,7 @@ from airflow import DAG
 from datagouvfr_data_pipelines.meta.task_functions import (
     monitor_dags,
     notification,
+    raise_dags_not_found,
 )
 
 
@@ -15,4 +16,4 @@ with DAG(
     tags=["monitoring"],
     catchup=False,
 ):
-    monitor_dags() >> notification()
+    monitor_dags() >> notification() >> raise_dags_not_found()

--- a/meta/dag.py
+++ b/meta/dag.py
@@ -1,11 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from datagouvfr_data_pipelines.meta.task_functions import (
-    monitor_dags,
-    notification,
-    raise_dags_not_found,
-)
+from datagouvfr_data_pipelines.meta.task_functions import monitor_dags, notification
 
 
 with DAG(
@@ -16,4 +12,4 @@ with DAG(
     tags=["monitoring"],
     catchup=False,
 ):
-    monitor_dags() >> notification() >> raise_dags_not_found()
+    monitor_dags() >> notification()

--- a/meta/task_functions.py
+++ b/meta/task_functions.py
@@ -76,8 +76,6 @@ def monitor_dags(
                 continue  # Raise an error only at the end to avoid skipping the rest of DAGs
             for dag_run in dag_runs:
                 start_date, end_date = dag_run.start_date, dag_run.end_date
-                if not start_date:
-                    raise TypeError(f"Start date must be defined for DagRun {dag_run}")
                 if not end_date:
                     continue  # Skipping currently running DAGs here
                 status = dag_run.state
@@ -97,7 +95,7 @@ def monitor_dags(
                         },
                     }
                 else:
-                    duration = end_date - start_date
+                    duration = end_date - start_date  # type: ignore : start_date should not be None
                     todays_runs[dag_id][end_date] = {
                         "success": True,
                         "duration": duration.total_seconds(),
@@ -189,14 +187,17 @@ def notification(**context):
                     + " \n "
                 )
     send_message(message, ping=list(ping))
-
-
-@task()
-def raise_dags_not_found(**context):
+    # Notify in case of DAGs on the config
     dags_not_found = context["ti"].xcom_pull(
         key="dags_not_found", task_ids="monitor_dags"
     )
     if len(dags_not_found) > 0:
-        raise NotFoundException(
-            f"The following DAGs in config.json were not found: {', '.join(dags_not_found)}"
+        message = "**❓️ Les DAGs suivants n'ont pas pu être trouvés:** " + "\n\n-"
+        missing_dags_list = ", \n\n - ".join(dags_not_found)
+        message += missing_dags_list
+        message += (
+            "\n\nSolutions:\n\n"
+            f"1. Vérifiez de possibles erreurs d'import sur l'instance {AIRFLOW_URL}.\n\n"
+            "2. Si ces DAGs sont obsolètes ou à renommer, consultez le fichier `/meta/config.json`"
         )
+        send_message(message, ping=list(ping))

--- a/meta/task_functions.py
+++ b/meta/task_functions.py
@@ -1,19 +1,23 @@
 import json
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytz
 from airflow.decorators import task
-from airflow.models import DagRun
-from airflow.providers.http.hooks.http import HttpHook
+from airflow_client.client.models.task_instance_response import TaskInstanceResponse
+from airflow_client.client.api import dag_api, dag_run_api, task_instance_api
+from airflow_client.client.exceptions import NotFoundException
+
+# from airflow.providers.http.hooks.http import HttpHook
 from airflow.utils.state import State
 from datagouvfr_data_pipelines.config import AIRFLOW_DAG_HOME, AIRFLOW_ENV, AIRFLOW_URL
 from datagouvfr_data_pipelines.utils.tchap import send_message
+from datagouvfr_data_pipelines.utils.airflow import AirflowAPI
 
+CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 local_timezone = pytz.timezone("Europe/Paris")
-http_hook = HttpHook(http_conn_id="HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR", method="GET")
 
 DEFAULT_DAG_OWNERS = [
     "geoffrey",
@@ -24,68 +28,85 @@ with open(f"{AIRFLOW_DAG_HOME}datagouvfr_data_pipelines/meta/config.json", "r") 
     config = json.load(f)
 
 
-def get_ids(config: dict) -> dict[str, str]:
-    # TODO: call api/v2 in Airflow3
-    dags = http_hook.run("api/v1/dags").json()["dags"]
+def get_ids(config: dict, api: dag_api.DAGApi) -> dict[str, str]:
+    dags = api.get_dags().dags
     ids = {}
     for raw_id, included in config.items():
         if not included:
             continue
         if raw_id.endswith("*"):
             ids |= {
-                d["dag_id"]: raw_id for d in dags if d["dag_id"].startswith(raw_id[:-1])
+                dag.dag_id: raw_id for dag in dags if dag.dag_id.startswith(raw_id[:-1])
             }
         else:
             ids[raw_id] = raw_id
     return ids
 
 
+def generate_task_log_url(task: TaskInstanceResponse):
+    return (
+        f"{AIRFLOW_URL}/dags/{task.dag_id}/runs/{task.dag_run_id}/tasks/{task.task_id}"
+    )
+
+
 @task()
 def monitor_dags(
-    date=(datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"),
+    date=(datetime.now() - timedelta(days=1)).replace(microsecond=0),
     **context,
 ):
-    dag_ids_to_monitor = get_ids(config)
-    logging.info("DAG list:", dag_ids_to_monitor)
-
-    logging.info("Start date considered:", date)
-    todays_runs = defaultdict(dict)
-    for dag_id in dag_ids_to_monitor:
-        dag_runs = DagRun.find(
-            dag_id=dag_id,
-            # /!\ this filters based on execution date and not start date, so we filter manually afterwards
-            # execution_start_date=start_date
-        )
-
-        for dag_run in dag_runs:
-            status = dag_run.get_state()
-            end_date = (
-                dag_run.end_date.strftime("%Y-%m-%d %H:%M:%S")
-                if dag_run.end_date
-                else None
-            )
-            if end_date and end_date >= date:
+    dags_not_found = []
+    with AirflowAPI(conn_name=CONN_NAME).client as client:
+        dag_api_client = dag_api.DAGApi(client)
+        dag_ids_to_monitor = get_ids(config, dag_api_client)
+        logging.info("DAG list:", dag_ids_to_monitor)
+        logging.info(f"Start date considered: {date.strftime('%Y-%m-%d %H:%M:%S')}")
+        todays_runs = defaultdict(dict)
+        for dag_id in dag_ids_to_monitor:
+            dag_run_api_client = dag_run_api.DagRunApi(client)
+            try:
+                date_dt = date.replace(
+                    tzinfo=timezone.utc
+                )  # The server needs a timezone-aware datetime or it throws a 500 error
+                dag_runs = dag_run_api_client.get_dag_runs(
+                    dag_id=dag_id,
+                    end_date_gte=date_dt,  # Does not filter out currently running DAGs
+                ).dag_runs
+            except NotFoundException:
+                dags_not_found.append(dag_id)
+                continue  # Raise an error only at the end to avoid skipping the rest of DAGs
+            for dag_run in dag_runs:
+                start_date, end_date = dag_run.start_date, dag_run.end_date
+                if not start_date:
+                    raise TypeError(f"Start date must be defined for DagRun {dag_run}")
+                if not end_date:
+                    continue  # Skipping currently running DAGs here
+                status = dag_run.state
                 if status != State.SUCCESS:
-                    failed_task_instances = dag_run.get_task_instances(
-                        state=State.FAILED
-                    )
+                    task_instance_api_client = task_instance_api.TaskInstanceApi(client)
+                    failed_task_instances = task_instance_api_client.get_task_instances(
+                        dag_id=dag_run.dag_id,
+                        dag_run_id=dag_run.dag_run_id,
+                        state=[State.FAILED],
+                    ).task_instances
                     todays_runs[dag_id][end_date] = {
                         "success": False,
                         "status": status,
                         "failed_tasks": {
-                            task.task_id: task.log_url for task in failed_task_instances
+                            task.task_id: generate_task_log_url(task)
+                            for task in failed_task_instances
                         },
                     }
                 else:
-                    duration = dag_run.end_date - dag_run.start_date
+                    duration = end_date - start_date
                     todays_runs[dag_id][end_date] = {
                         "success": True,
                         "duration": duration.total_seconds(),
                     }
-    context["ti"].xcom_push(key="todays_runs", value=todays_runs)
-    # sending the mapping between dag ids and prefixes in the config
-    context["ti"].xcom_push(key="dag_ids", value=dag_ids_to_monitor)
-    return todays_runs
+        context["ti"].xcom_push(key="dags_not_found", value=dags_not_found)
+        context["ti"].xcom_push(key="todays_runs", value=todays_runs)
+        # sending the mapping between dag ids and prefixes in the config
+        context["ti"].xcom_push(key="dag_ids", value=dag_ids_to_monitor)
+        return todays_runs
 
 
 @task()
@@ -168,3 +189,14 @@ def notification(**context):
                     + " \n "
                 )
     send_message(message, ping=list(ping))
+
+
+@task()
+def raise_dags_not_found(**context):
+    dags_not_found = context["ti"].xcom_pull(
+        key="dags_not_found", task_ids="monitor_dags"
+    )
+    if len(dags_not_found) > 0:
+        raise NotFoundException(
+            f"The following DAGs in config.json were not found: {', '.join(dags_not_found)}"
+        )

--- a/utils/airflow.py
+++ b/utils/airflow.py
@@ -1,0 +1,56 @@
+import requests
+from pydantic import BaseModel
+
+from airflow.hooks.base import BaseHook
+# from airflow.sdk.bases.hook import BaseHook #to use in v3
+
+import airflow_client.client
+
+
+# What we expect back from auth/token
+class AirflowAccessTokenResponse(BaseModel):
+    access_token: str
+
+
+# An optional helper function to retrieve an access token
+def get_airflow_client_access_token(
+    host: str,
+    username: str,
+    password: str,
+) -> str:
+    url = f"{host}/auth/token"
+    payload = {
+        "username": username,
+        "password": password,
+    }
+    headers = {"Content-Type": "application/json"}
+    response = requests.post(url, json=payload, headers=headers)
+    if response.status_code != 201:
+        raise RuntimeError(
+            f"Failed to get access token: {response.status_code} {response.text}"
+        )
+    response_success = AirflowAccessTokenResponse(**response.json())
+    return response_success.access_token
+
+
+class AirflowAPI:
+    def __init__(self, conn_name):
+        airflow_conn = BaseHook.get_connection(conn_name)
+
+        # Defining the host is optional and defaults to http://localhost
+        # See configuration.py for a list of all supported configuration parameters.
+        host = airflow_conn.host
+        configuration = airflow_client.client.Configuration(host=host)
+
+        # The client must configure the authentication and authorization parameters
+        # in accordance with the API server security policy.
+        # Examples for each auth method are provided below, use the example that
+        # satisfies your auth use case.
+        configuration.access_token = get_airflow_client_access_token(
+            host=host,
+            username=airflow_conn.login,
+            password=airflow_conn.password,
+        )
+
+        # Instance of the API client to use as a context
+        self.client = airflow_client.client.ApiClient(configuration)

--- a/utils/airflow.py
+++ b/utils/airflow.py
@@ -1,8 +1,7 @@
 import requests
 from pydantic import BaseModel
 
-from airflow.hooks.base import BaseHook
-# from airflow.sdk.bases.hook import BaseHook #to use in v3
+from airflow.sdk.bases.hook import BaseHook
 
 import airflow_client.client
 
@@ -39,15 +38,20 @@ class AirflowAPI:
 
         # Defining the host is optional and defaults to http://localhost
         # See configuration.py for a list of all supported configuration parameters.
-        host = airflow_conn.host
-        configuration = airflow_client.client.Configuration(host=host)
-
+        if not airflow_conn.schema or not airflow_conn.host:
+            raise TypeError(f"Schema and host must be set for connection {conn_name}")
+        self.host = f"{airflow_conn.schema}://{airflow_conn.host}"
+        configuration = airflow_client.client.Configuration(host=self.host)
+        if not airflow_conn.login or not airflow_conn.password:
+            raise TypeError(
+                f"Username and password must be set for connection {conn_name}"
+            )
         # The client must configure the authentication and authorization parameters
         # in accordance with the API server security policy.
         # Examples for each auth method are provided below, use the example that
         # satisfies your auth use case.
         configuration.access_token = get_airflow_client_access_token(
-            host=host,
+            host=self.host,
             username=airflow_conn.login,
             password=airflow_conn.password,
         )


### PR DESCRIPTION
This PR encompasses : 

**1. A new `utils` module :** an Airflow API connector, implementing the new correct way to communicate with Airflow DB in v3

**2. An upgrade to the DAG `maintenance_clean_logs_and_runs` :** now uses the airflow API to access DagRun objects

**3. Multiples upgrades to the DAG `meta_dag`:** 
  - now uses the airflow API to access Dag, DagRun and TaskInstance objects
  - wait until the end of the DAG to ~~raise an error~~ send a Tchap notification in case of DAGs name not being matched in the DB : both 1. to help with maintenance of the file `meta/config.json` if not matching the DB anymore, and 2. for testing (it allows the DAG to run in local when some DAGs are missing - this is expected due to environment diff between dev and prod)
  ~~- added to the DAGs to monitor in `meta/config.json` so the next successful run can detect an issue with the prior, in case no one see the notifications are missing~~

**Note: this PR requires apache-airflow-client to be added to the infra to run, it will throw an error otherwise.**