### PR TITLE
Add dags decoupage_administratif and contours_administratifs

### DIFF
--- a/data_processing/contours_administratifs/README.md
+++ b/data_processing/contours_administratifs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+## data_processing_update_contours_administratifs_ressources_list_datagouv
+
+| Information | Valeur |
+| -------- | -------- |
+| Fichier source     | `dag.py`     |
+| Description | Ce traitement permet de mettre à jour la liste des ressources associées au dataset [Contours administratifs](https://www.data.gouv.fr/datasets/contours-administratifs), utilisé pour fournir les données consolidées pour l'API Découpage Administratif|
+| Fréquence de mise à jour | Annuelle|
+| Données sources| Liste des fichiers S3 sur le bucket S3 OVH `contours-administratifs` hébergé sur la région RBX |
+| Données de sorties | [Liste des ressources du jeu de données sur data.gouv](https://www.data.gouv.fr/datasets/contours-administratifs) |
+| Channel Tchap d'information | Non |

--- a/data_processing/contours_administratifs/config.json
+++ b/data_processing/contours_administratifs/config.json
@@ -1,0 +1,10 @@
+{
+    "contours-administratifs": {
+        "dev": {
+            "dataset_id": "683424e996857155175d4f68"
+        },
+        "prod": {
+            "dataset_id": "683424e996857155175d4f68"
+        }
+    }
+}

--- a/data_processing/contours_administratifs/dag.py
+++ b/data_processing/contours_administratifs/dag.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from airflow.models import DAG
 
 from datagouvfr_data_pipelines.data_processing.contours_administratifs.task_functions import (
@@ -16,10 +16,10 @@ default_args = {
     "provide_context": True,
 }
 
-
 with DAG(
     dag_id=DAG_NAME,
-    schedule_interval=None,
+    schedule="0 0 1 * *",
+    start_date=datetime(2026, 5, 11),
     dagrun_timeout=timedelta(minutes=240),
     tags=["contours-administratifs", "resources", "datagouv"],
     catchup=False,

--- a/data_processing/contours_administratifs/dag.py
+++ b/data_processing/contours_administratifs/dag.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+from airflow.models import DAG
+
+from datagouvfr_data_pipelines.data_processing.contours_administratifs.task_functions import (
+    update_temporal_coverage,
+    update_create_resources,
+    specific_sort_ressources,
+    notification,
+)
+
+DAG_NAME = "data_processing_update_contours_administratifs_ressources_list_datagouv"
+
+default_args = {
+    "retries": 5,
+    "retry_delay": timedelta(minutes=5),
+    "provide_context": True,
+}
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    schedule_interval=None,
+    dagrun_timeout=timedelta(minutes=240),
+    tags=["contours-administratifs", "resources", "datagouv"],
+    catchup=False,
+    default_args=default_args,
+) as dag:
+    (
+        update_temporal_coverage()
+        >> update_create_resources()
+        >> specific_sort_ressources()
+        >> notification()
+    )

--- a/data_processing/contours_administratifs/task_functions.py
+++ b/data_processing/contours_administratifs/task_functions.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import mimetypes
+import re
+
+
+from airflow.decorators import task
+
+# from datagouv import Client
+from datagouvfr_data_pipelines.config import (
+    AIRFLOW_ENV,
+    AIRFLOW_DAG_HOME,
+    S3_URL_RBX,
+)
+from datagouvfr_data_pipelines.utils.datagouv import (
+    local_client,
+)
+from datagouvfr_data_pipelines.utils.s3 import S3Client
+from datagouvfr_data_pipelines.utils.tchap import send_message
+import requests
+
+mimetypes.init()
+
+# Variables directly below need an update each year
+LATEST_YEAR = "2026"
+END_DATE = "2026-04-01"
+
+DAG_BUCKET_NAME = "contours-administratifs"
+DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
+with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}contours_administratifs/config.json") as fp:
+    config = json.load(fp)
+
+REGEX = r"[0-9]+m"
+DATASET_ID = config[DAG_BUCKET_NAME][AIRFLOW_ENV]["dataset_id"]
+
+dataset = local_client.dataset(DATASET_ID)
+
+
+def get_files_info_from_s3():
+    content = S3Client(s3_url=S3_URL_RBX, bucket=DAG_BUCKET_NAME).get_files_from_prefix(
+        prefix="", ignore_airflow_env=True
+    )
+    s3_paths_to_reference = [
+        s3_path
+        for s3_path in content
+        if len([j for j in ["simplified", "fgb", "shp", "latest"] if j in s3_path]) == 0
+    ]
+    return s3_paths_to_reference
+
+
+def generate_files_infos_contours_administratifs(items):
+    output = []
+    for i in items:
+        paths = i.split("/")
+        year = paths[0]
+        name = paths[2]
+        if "communes-associees-deleguees" in name:
+            mytitle = "Communes associées/déléguées"
+            priority = 80
+        elif "communes" in name:
+            mytitle = "Communes"
+            priority = 100
+        elif "departements" in name:
+            mytitle = "Départements"
+            priority = 60
+        elif "regions" in name:
+            mytitle = "Régions"
+            priority = 50
+        elif "epci" in name:
+            mytitle = "EPCI"
+            priority = 70
+        elif "mairies" in name:
+            mytitle = "Mairies"
+            priority = 90
+        elif "arrondissements-municipaux" in name:
+            mytitle = "Arrondissements municipaux"
+            priority = 90
+        else:
+            pass
+        matches = [j for j in re.finditer(REGEX, name, re.MULTILINE)]
+        text_simplify = " " + matches[0].group() if len(matches) == 1 else ""
+        priority = (
+            float(priority)
+            if text_simplify == ""
+            else float(priority) + 1 / float(text_simplify.replace("m", ""))
+        )
+        if "2025-01-08" in name:
+            priority = 99 + float(year)
+            year = year + " en date du 2025-01-08"
+        else:
+            priority = priority + float(year)
+        mytitle = (
+            mytitle
+            + " "
+            + year
+            + text_simplify
+            + " (format GeoJSON"
+            + (" compressé GZ" if ".gz" in name else "")
+            + ")"
+        )
+        remote_url = "https://contours-administratifs.s3.rbx.io.cloud.ovh.net/" + i
+        ext = ".".join(remote_url.split("/")[-1].split(".")[1:])
+        r = requests.head(remote_url)
+        filesize = r.headers["Content-Length"]
+        mime = mimetypes.types_map.get("." + ext)
+        output.append(
+            {
+                "title": mytitle,
+                "url": remote_url,
+                "s3_path": i,
+                "filesize": filesize,
+                "mime": mime,
+                "format": ext,
+                "type": ("main" if LATEST_YEAR in year else "other"),
+                "priority": priority,
+            }
+        )
+    output = sorted(output, key=lambda k: k["priority"])
+    return output
+
+
+@task
+def update_create_resources():
+    ressources_s3 = generate_files_infos_contours_administratifs(
+        get_files_info_from_s3()
+    )
+    urls_res_dataset = {
+        res.url[res.url.index("/20") + 1 :]: res for res in dataset.resources
+    }
+    for res in ressources_s3:
+        if res.get("s3_path") in urls_res_dataset:
+            logging.info("Existing ressource. Only update")
+            payload = {
+                "url": res.get("url"),
+                "title": res.get("title"),
+                "filesize": res.get("filesize"),
+                "format": res.get("format"),
+                "mime": res.get("mime"),
+                "type": res.get("type"),
+            }
+            logging.info(payload)
+            urls_res_dataset[res.get("s3_path")].update(payload)
+        else:
+            logging.info("Create new ressource", res.get("s3_path"))
+            payload = {
+                "url": res.get("url"),
+                "title": res.get("title"),
+                "filesize": res.get("filesize"),
+                "format": res.get("format"),
+                "mime": res.get("mime"),
+                "type": res.get("type"),
+            }
+            dataset.create_remote(payload=payload)
+            logging.info(payload)
+
+
+@task
+def specific_sort_ressources():
+    dataset_reloaded = local_client.dataset(DATASET_ID)
+    urls_res_dataset_reloaded = {
+        res.url[res.url.index("/20") + 1 :]: res for res in dataset_reloaded.resources
+    }
+    sorted_ids_res_datagouv = [
+        urls_res_dataset_reloaded[i].id for i in urls_res_dataset_reloaded
+    ]
+    local_client.session.put(
+        dataset_reloaded.uri + "resources/",
+        json=sorted_ids_res_datagouv,
+    )
+
+
+@task()
+def update_temporal_coverage():
+    dataset.update({"temporal_coverage": {"end": END_DATE, "start": "2019-01-01"}})
+
+
+@task()
+def notification():
+    send_message(
+        text=(
+            f"📣 Mise à jour de la liste des ressources sur data.gouv.fr pour les données {DAG_BUCKET_NAME}.\n\n"
+            f"- Données stockées sur S3 - Bucket {DAG_BUCKET_NAME}\n"
+            f"- Données publiées [sur data.gouv.fr]({local_client.base_url}/datasets/{DATASET_ID}/)"
+        )
+    )

--- a/data_processing/decoupage_administratif/README.md
+++ b/data_processing/decoupage_administratif/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+## data_processing_update_decoupage_administratif_ressources_list_datagouv
+
+| Information | Valeur |
+| -------- | -------- |
+| Fichier source     | `dag.py`     |
+| Description | Ce traitement permet de mettre à jour la liste des ressources associées au dataset [Découpage administratif](https://www.data.gouv.fr/datasets/decoupage-administratif-1), utilisé pour fournir les données consolidées pour l'API Découpage Administratif|
+| Fréquence de mise à jour | Annuelle|
+| Données sources| [Fichiers hébergés sur NPM (sur le site [npmjs.com](https://www.npmjs.com/package/@etalab/decoupage-administratif))|
+| Données de sorties | [Liste des ressources du jeu de données sur data.gouv](https://www.data.gouv.fr/datasets/decoupage-administratif-1) |
+| Channel Tchap d'information | Non |

--- a/data_processing/decoupage_administratif/config.json
+++ b/data_processing/decoupage_administratif/config.json
@@ -1,0 +1,10 @@
+{
+    "decoupage-administratif": {
+        "dev": {
+            "dataset_id": "683424208089f77caf78f448"
+        },
+        "prod": {
+            "dataset_id": "683424208089f77caf78f448"
+        }
+    }
+}

--- a/data_processing/decoupage_administratif/dag.py
+++ b/data_processing/decoupage_administratif/dag.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from airflow.models import DAG
 
 from datagouvfr_data_pipelines.data_processing.decoupage_administratif.task_functions import (
@@ -19,7 +19,8 @@ default_args = {
 
 with DAG(
     dag_id=DAG_NAME,
-    schedule_interval=None,
+    schedule="0 0 1 * *",
+    start_date=datetime(2026, 5, 11),
     dagrun_timeout=timedelta(minutes=240),
     tags=["decoupage-administratif", "resources", "datagouv"],
     catchup=False,

--- a/data_processing/decoupage_administratif/dag.py
+++ b/data_processing/decoupage_administratif/dag.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+from airflow.models import DAG
+
+from datagouvfr_data_pipelines.data_processing.decoupage_administratif.task_functions import (
+    update_create_resources,
+    specific_sort_ressources,
+    update_temporal_coverage,
+    notification,
+)
+
+DAG_NAME = "data_processing_update_decoupage_administratif_ressources_list_datagouv"
+
+default_args = {
+    "retries": 5,
+    "retry_delay": timedelta(minutes=5),
+    "provide_context": True,
+}
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    schedule_interval=None,
+    dagrun_timeout=timedelta(minutes=240),
+    tags=["decoupage-administratif", "resources", "datagouv"],
+    catchup=False,
+    default_args=default_args,
+) as dag:
+    (
+        update_temporal_coverage()
+        >> update_create_resources()
+        >> specific_sort_ressources()
+        >> notification()
+    )

--- a/data_processing/decoupage_administratif/task_functions.py
+++ b/data_processing/decoupage_administratif/task_functions.py
@@ -86,13 +86,15 @@ NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()
 
 def generate_files_infos_decoupage_administratif():
     output = []
-    priority_by_type = {i:float((idx + 1) * 10) for idx, i in enumerate(reversed(commons_dict.keys()))}
+    priority_by_type = {
+        i: float((idx + 1) * 10) for idx, i in enumerate(reversed(commons_dict.keys()))
+    }
     for year, version in NPM_PACKAGE_VERSIONS.items():
         type_file = "main" if LATEST_YEAR in year else "other"
         mime_file = "application/json"
         format_file = "json"
         if version == "0.8.0":
-            priority = priority_by_type['epci'] + 1 / float(2020)
+            priority = priority_by_type["epci"] + 1 / float(2020)
             mytitle = "Données EPCI 2020"
             url = f"{base_unpkg_decoupage_administratif}@{version}/data/epci.json"
             r = requests.get(url, stream=True, headers={"Accept-Encoding": None})
@@ -165,7 +167,7 @@ def update_create_resources():
                 "mime": res.get("mime"),
                 "type": res.get("type"),
             }
-            logging.info(payload)
+            logging.info(json.dumps(payload))
             urls_res_dataset[res.get("title")].update(payload)
         else:
             logging.info("Create new ressource", res.get("url"))
@@ -178,18 +180,23 @@ def update_create_resources():
                 "type": res.get("type"),
             }
             dataset.create_remote(payload=payload)
-            logging.info(payload)
+            logging.info(json.dumps(payload))
 
 
 @task
 def specific_sort_ressources():
     dataset_reloaded = local_client.dataset(DATASET_ID)
-    ressources_unpkg = generate_files_infos_decoupage_administratif()    
-    urls_res_dataset_reloaded = {
-        res.url: res for res in dataset_reloaded.resources
-    }
+    ressources_unpkg = generate_files_infos_decoupage_administratif()
+    urls_res_dataset_reloaded = {res.url: res for res in dataset_reloaded.resources}
     # sorted_ids_res_datagouv = [urls_res_dataset_reloaded[j[0]].id for j in sorted([[i.get('url'), i.get('priority')] for i in ressources_unpkg], key=lambda x: x[1]) if j[0] in urls_res_dataset_reloaded]
-    sorted_ids_res_datagouv = [urls_res_dataset_reloaded[j[0]].id for j in sorted([[i.get('url'), i.get('priority')] for i in ressources_unpkg], key=lambda x: x[1]) if j[0]]
+    sorted_ids_res_datagouv = [
+        urls_res_dataset_reloaded[j[0]].id
+        for j in sorted(
+            [[i.get("url"), i.get("priority")] for i in ressources_unpkg],
+            key=lambda x: x[1],
+        )
+        if j[0]
+    ]
     local_client.session.put(
         dataset_reloaded.uri + "resources/",
         json=sorted_ids_res_datagouv,
@@ -210,6 +217,3 @@ def notification():
             f"- Données publiées [sur data.gouv.fr]({local_client.base_url}/datasets/{DATASET_ID}/)"
         )
     )
-
-
-NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()

--- a/data_processing/decoupage_administratif/task_functions.py
+++ b/data_processing/decoupage_administratif/task_functions.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import mimetypes
-import re
 
 
 from airflow.decorators import task
@@ -10,7 +9,6 @@ from airflow.decorators import task
 from datagouvfr_data_pipelines.config import (
     AIRFLOW_ENV,
     AIRFLOW_DAG_HOME,
-    S3_URL_RBX,
 )
 from datagouvfr_data_pipelines.utils.datagouv import (
     local_client,
@@ -24,40 +22,33 @@ mimetypes.init()
 LATEST_YEAR = "2026"
 END_DATE = "2026-04-01"
 
-commons = [
-    'communes',
-    'epci',
-    'departements',
-    'regions',
-    'arrondissements'
-]
+commons = ["communes", "epci", "departements", "regions", "arrondissements"]
 commons_name = [
-    'communes dont communes associées/déléguées et arrondissements municipaux',
-    'EPCI',
-    'départements',
-    'régions',
-    'arrondissements'
+    "communes dont communes associées/déléguées et arrondissements municipaux",
+    "EPCI",
+    "départements",
+    "régions",
+    "arrondissements",
 ]
 commons_dict = dict(zip(commons, commons_name))
-commons_dict['ept'] = 'EPT'
+commons_dict["ept"] = "EPT"
 
 
 versions_prefix = {
-    '2019': '0.7',
-    '2020': '0.8',
-    '2021': '1.',
-    '2022': '2.',
-    '2023': '3.',
-    '2024': '4.',
-    '2025': '5.',
-    '2026': '6.'
+    "2019": "0.7",
+    "2020": "0.8",
+    "2021": "1.",
+    "2022": "2.",
+    "2023": "3.",
+    "2024": "4.",
+    "2025": "5.",
+    "2026": "6.",
 }
 
-base_unpkg_decoupage_administratif = 'https://unpkg.com/@etalab/decoupage-administratif'
+base_unpkg_decoupage_administratif = "https://unpkg.com/@etalab/decoupage-administratif"
 
 
-
-DAG_NAME = 'decoupage-administratif'
+DAG_NAME = "decoupage-administratif"
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}decoupage_administratif/config.json") as fp:
     config = json.load(fp)
@@ -66,77 +57,105 @@ DATASET_ID = config[DAG_NAME][AIRFLOW_ENV]["dataset_id"]
 
 dataset = local_client.dataset(DATASET_ID)
 
+
 def npm_package_metadata(package_name):
-    url_npm_registry = f'https://registry.npmjs.org/{package_name}/'
+    url_npm_registry = f"https://registry.npmjs.org/{package_name}/"
     r_url_npm_registry = requests.get(url_npm_registry)
     return r_url_npm_registry.json()
 
+
 def npm_package_latest_version_for_years():
     versions = {}
-    metadata = npm_package_metadata('@etalab/decoupage-administratif')
-    npm_package_versions_without_alpha_beta = [i for i in metadata.get('versions').keys() if '-' not in i]
+    metadata = npm_package_metadata("@etalab/decoupage-administratif")
+    npm_package_versions_without_alpha_beta = [
+        i for i in metadata.get("versions").keys() if "-" not in i
+    ]
     for year, version_prefix in versions_prefix.items():
-        versions[year] = sorted([j for j in npm_package_versions_without_alpha_beta if j.startswith(version_prefix)])[-1]
+        versions[year] = sorted(
+            [
+                j
+                for j in npm_package_versions_without_alpha_beta
+                if j.startswith(version_prefix)
+            ]
+        )[-1]
     return versions
+
 
 NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()
 
+
 def generate_files_infos_decoupage_administratif():
     output = []
+    priority_by_type = {i:float((idx + 1) * 10) for idx, i in enumerate(reversed(commons_dict.keys()))}
     for year, version in NPM_PACKAGE_VERSIONS.items():
-        type_file = 'main' if LATEST_YEAR in year else 'other'
-        mime_file = 'application/json'
-        format_file = 'json'
-        if version == '0.8.0':
-            mytitle = 'Données EPCI 2020'
-            url = (f'{base_unpkg_decoupage_administratif}@{version}/data/epci.json')
-            r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
-            mysize = r.headers['Content-Length']
-            output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+        type_file = "main" if LATEST_YEAR in year else "other"
+        mime_file = "application/json"
+        format_file = "json"
+        if version == "0.8.0":
+            priority = priority_by_type['epci'] + 1 / float(2020)
+            mytitle = "Données EPCI 2020"
+            url = f"{base_unpkg_decoupage_administratif}@{version}/data/epci.json"
+            r = requests.get(url, stream=True, headers={"Accept-Encoding": None})
+            mysize = r.headers["Content-Length"]
+            output.append(
+                {
+                    "title": mytitle,
+                    "url": url,
+                    "filesize": mysize,
+                    "type": type_file,
+                    "mime": mime_file,
+                    "format": format_file,
+                    "year": year,
+                    "priority": priority,
+                }
+            )
         elif int(year) >= 2023:
-            for name in reversed(commons + ['ept']):
-                url = (f'{base_unpkg_decoupage_administratif}@{version}/data/{name}.json')
-                mytitle = f'Données {commons_dict[name]} {year}'
-                r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
-                mysize = r.headers['Content-Length']
-                output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+            for name in reversed(commons + ["ept"]):
+                priority = priority_by_type[name] + 1 / float(year)
+                url = f"{base_unpkg_decoupage_administratif}@{version}/data/{name}.json"
+                mytitle = f"Données {commons_dict[name]} {year}"
+                r = requests.get(url, stream=True, headers={"Accept-Encoding": None})
+                mysize = r.headers["Content-Length"]
+                output.append(
+                    {
+                        "title": mytitle,
+                        "url": url,
+                        "filesize": mysize,
+                        "type": type_file,
+                        "mime": mime_file,
+                        "format": format_file,
+                        "year": year,
+                        "priority": priority,
+                    }
+                )
         else:
             for name in reversed(commons):
-                url = (f'{base_unpkg_decoupage_administratif}@{version}/data/{name}.json')
-                mytitle = f'Données {commons_dict[name]} {year}'
-                r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
-                mysize = r.headers['Content-Length']
-                output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+                priority = priority_by_type[name] + 1 / float(year)
+                url = f"{base_unpkg_decoupage_administratif}@{version}/data/{name}.json"
+                mytitle = f"Données {commons_dict[name]} {year}"
+                r = requests.get(url, stream=True, headers={"Accept-Encoding": None})
+                mysize = r.headers["Content-Length"]
+                output.append(
+                    {
+                        "title": mytitle,
+                        "url": url,
+                        "filesize": mysize,
+                        "type": type_file,
+                        "mime": mime_file,
+                        "format": format_file,
+                        "year": year,
+                        "priority": priority,
+                    }
+                )
     return output
-
-ressources_unpkg = generate_files_infos_decoupage_administratif()
-urls_res_s3 = [i.get('url') for i in ressources_unpkg]
-
-
-for res in dataset.resources:
-    if res.url in urls_res_mc:
-        print('Existing ressource')
-
-urls_res_dataset = [i.url for i in dataset.resources]
-
-for res_mc in ressources_unpkg:
-    if res_mc['url'] not in urls_res_dataset:
-        resource = client_datagouv.resource().create_remote(
-            payload={"url": res_mc['url'], "title": res_mc['title'], "size": res_mc['size'], "type": res_mc['type']},
-            dataset_id=dataset.id,
-        )
 
 
 @task
 def update_create_resources():
-    ressources_s3 = generate_files_infos_contours_administratifs(
-        get_files_info_from_s3()
-    )
-    urls_res_dataset = {
-        res.url[res.url.index("/20") + 1 :]: res for res in dataset.resources
-    }
-    for res in ressources_s3:
-        if res.get("s3_path") in urls_res_dataset:
+    ressources_unpkg = generate_files_infos_decoupage_administratif()
+    urls_res_dataset = {res.title: res for res in dataset.resources}
+    for res in ressources_unpkg:
+        if res.get("title") in urls_res_dataset:
             logging.info("Existing ressource. Only update")
             payload = {
                 "url": res.get("url"),
@@ -147,9 +166,9 @@ def update_create_resources():
                 "type": res.get("type"),
             }
             logging.info(payload)
-            urls_res_dataset[res.get("s3_path")].update(payload)
+            urls_res_dataset[res.get("title")].update(payload)
         else:
-            logging.info("Create new ressource", res.get("s3_path"))
+            logging.info("Create new ressource", res.get("url"))
             payload = {
                 "url": res.get("url"),
                 "title": res.get("title"),
@@ -165,12 +184,12 @@ def update_create_resources():
 @task
 def specific_sort_ressources():
     dataset_reloaded = local_client.dataset(DATASET_ID)
+    ressources_unpkg = generate_files_infos_decoupage_administratif()    
     urls_res_dataset_reloaded = {
-        res.url[res.url.index("/20") + 1 :]: res for res in dataset_reloaded.resources
+        res.url: res for res in dataset_reloaded.resources
     }
-    sorted_ids_res_datagouv = [
-        urls_res_dataset_reloaded[i].id for i in urls_res_dataset_reloaded
-    ]
+    # sorted_ids_res_datagouv = [urls_res_dataset_reloaded[j[0]].id for j in sorted([[i.get('url'), i.get('priority')] for i in ressources_unpkg], key=lambda x: x[1]) if j[0] in urls_res_dataset_reloaded]
+    sorted_ids_res_datagouv = [urls_res_dataset_reloaded[j[0]].id for j in sorted([[i.get('url'), i.get('priority')] for i in ressources_unpkg], key=lambda x: x[1]) if j[0]]
     local_client.session.put(
         dataset_reloaded.uri + "resources/",
         json=sorted_ids_res_datagouv,
@@ -179,22 +198,18 @@ def specific_sort_ressources():
 
 @task()
 def update_temporal_coverage():
-    dataset.update({
-        "temporal_coverage": {
-            "end": END_DATE,
-            "start": "2019-01-01"
-        }
-    })
+    dataset.update({"temporal_coverage": {"end": END_DATE, "start": "2019-01-01"}})
 
 
 @task()
 def notification():
     send_message(
         text=(
-            f"📣 Mise à jour de la liste des ressources sur data.gouv.fr pour les données {DAG_BUCKET_NAME}.\n\n"
-            f"- Données stockées sur S3 - Bucket {DAG_BUCKET_NAME}\n"
+            f"📣 Mise à jour de la liste des ressources sur data.gouv.fr pour les données {DAG_NAME}.\n\n"
+            f"- Données stockées sur npmjs - https://www.npmjs.com/package/@etalab/decoupage-administratif\n"
             f"- Données publiées [sur data.gouv.fr]({local_client.base_url}/datasets/{DATASET_ID}/)"
         )
     )
+
 
 NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()

--- a/data_processing/decoupage_administratif/task_functions.py
+++ b/data_processing/decoupage_administratif/task_functions.py
@@ -1,0 +1,200 @@
+import json
+import logging
+import mimetypes
+import re
+
+
+from airflow.decorators import task
+
+# from datagouv import Client
+from datagouvfr_data_pipelines.config import (
+    AIRFLOW_ENV,
+    AIRFLOW_DAG_HOME,
+    S3_URL_RBX,
+)
+from datagouvfr_data_pipelines.utils.datagouv import (
+    local_client,
+)
+from datagouvfr_data_pipelines.utils.tchap import send_message
+import requests
+
+mimetypes.init()
+
+# Variables directly below need an update each year
+LATEST_YEAR = "2026"
+END_DATE = "2026-04-01"
+
+commons = [
+    'communes',
+    'epci',
+    'departements',
+    'regions',
+    'arrondissements'
+]
+commons_name = [
+    'communes dont communes associées/déléguées et arrondissements municipaux',
+    'EPCI',
+    'départements',
+    'régions',
+    'arrondissements'
+]
+commons_dict = dict(zip(commons, commons_name))
+commons_dict['ept'] = 'EPT'
+
+
+versions_prefix = {
+    '2019': '0.7',
+    '2020': '0.8',
+    '2021': '1.',
+    '2022': '2.',
+    '2023': '3.',
+    '2024': '4.',
+    '2025': '5.',
+    '2026': '6.'
+}
+
+base_unpkg_decoupage_administratif = 'https://unpkg.com/@etalab/decoupage-administratif'
+
+
+
+DAG_NAME = 'decoupage-administratif'
+DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
+with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}decoupage_administratif/config.json") as fp:
+    config = json.load(fp)
+
+DATASET_ID = config[DAG_NAME][AIRFLOW_ENV]["dataset_id"]
+
+dataset = local_client.dataset(DATASET_ID)
+
+def npm_package_metadata(package_name):
+    url_npm_registry = f'https://registry.npmjs.org/{package_name}/'
+    r_url_npm_registry = requests.get(url_npm_registry)
+    return r_url_npm_registry.json()
+
+def npm_package_latest_version_for_years():
+    versions = {}
+    metadata = npm_package_metadata('@etalab/decoupage-administratif')
+    npm_package_versions_without_alpha_beta = [i for i in metadata.get('versions').keys() if '-' not in i]
+    for year, version_prefix in versions_prefix.items():
+        versions[year] = sorted([j for j in npm_package_versions_without_alpha_beta if j.startswith(version_prefix)])[-1]
+    return versions
+
+NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()
+
+def generate_files_infos_decoupage_administratif():
+    output = []
+    for year, version in NPM_PACKAGE_VERSIONS.items():
+        type_file = 'main' if LATEST_YEAR in year else 'other'
+        mime_file = 'application/json'
+        format_file = 'json'
+        if version == '0.8.0':
+            mytitle = 'Données EPCI 2020'
+            url = (f'{base_unpkg_decoupage_administratif}@{version}/data/epci.json')
+            r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
+            mysize = r.headers['Content-Length']
+            output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+        elif int(year) >= 2023:
+            for name in reversed(commons + ['ept']):
+                url = (f'{base_unpkg_decoupage_administratif}@{version}/data/{name}.json')
+                mytitle = f'Données {commons_dict[name]} {year}'
+                r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
+                mysize = r.headers['Content-Length']
+                output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+        else:
+            for name in reversed(commons):
+                url = (f'{base_unpkg_decoupage_administratif}@{version}/data/{name}.json')
+                mytitle = f'Données {commons_dict[name]} {year}'
+                r = requests.get(url, stream=True, headers={'Accept-Encoding': None})
+                mysize = r.headers['Content-Length']
+                output.append({'title': mytitle, 'url': url, 'filesize': mysize, 'type': type_file, 'mime': mime_file, 'format': format_file})
+    return output
+
+ressources_unpkg = generate_files_infos_decoupage_administratif()
+urls_res_s3 = [i.get('url') for i in ressources_unpkg]
+
+
+for res in dataset.resources:
+    if res.url in urls_res_mc:
+        print('Existing ressource')
+
+urls_res_dataset = [i.url for i in dataset.resources]
+
+for res_mc in ressources_unpkg:
+    if res_mc['url'] not in urls_res_dataset:
+        resource = client_datagouv.resource().create_remote(
+            payload={"url": res_mc['url'], "title": res_mc['title'], "size": res_mc['size'], "type": res_mc['type']},
+            dataset_id=dataset.id,
+        )
+
+
+@task
+def update_create_resources():
+    ressources_s3 = generate_files_infos_contours_administratifs(
+        get_files_info_from_s3()
+    )
+    urls_res_dataset = {
+        res.url[res.url.index("/20") + 1 :]: res for res in dataset.resources
+    }
+    for res in ressources_s3:
+        if res.get("s3_path") in urls_res_dataset:
+            logging.info("Existing ressource. Only update")
+            payload = {
+                "url": res.get("url"),
+                "title": res.get("title"),
+                "filesize": res.get("filesize"),
+                "format": res.get("format"),
+                "mime": res.get("mime"),
+                "type": res.get("type"),
+            }
+            logging.info(payload)
+            urls_res_dataset[res.get("s3_path")].update(payload)
+        else:
+            logging.info("Create new ressource", res.get("s3_path"))
+            payload = {
+                "url": res.get("url"),
+                "title": res.get("title"),
+                "filesize": res.get("filesize"),
+                "format": res.get("format"),
+                "mime": res.get("mime"),
+                "type": res.get("type"),
+            }
+            dataset.create_remote(payload=payload)
+            logging.info(payload)
+
+
+@task
+def specific_sort_ressources():
+    dataset_reloaded = local_client.dataset(DATASET_ID)
+    urls_res_dataset_reloaded = {
+        res.url[res.url.index("/20") + 1 :]: res for res in dataset_reloaded.resources
+    }
+    sorted_ids_res_datagouv = [
+        urls_res_dataset_reloaded[i].id for i in urls_res_dataset_reloaded
+    ]
+    local_client.session.put(
+        dataset_reloaded.uri + "resources/",
+        json=sorted_ids_res_datagouv,
+    )
+
+
+@task()
+def update_temporal_coverage():
+    dataset.update({
+        "temporal_coverage": {
+            "end": END_DATE,
+            "start": "2019-01-01"
+        }
+    })
+
+
+@task()
+def notification():
+    send_message(
+        text=(
+            f"📣 Mise à jour de la liste des ressources sur data.gouv.fr pour les données {DAG_BUCKET_NAME}.\n\n"
+            f"- Données stockées sur S3 - Bucket {DAG_BUCKET_NAME}\n"
+            f"- Données publiées [sur data.gouv.fr]({local_client.base_url}/datasets/{DATASET_ID}/)"
+        )
+    )
+
+NPM_PACKAGE_VERSIONS = npm_package_latest_version_for_years()


### PR DESCRIPTION
We need to update resources published on https://www.data.gouv.fr/datasets/decoupage-administratif-1 and https://www.data.gouv.fr/datasets/contours-administratifs annually but the process was not documented, only in a local script for a first run.
These resources are used for running the API Découpage Administratif
This PR purpose is to solve the issue.
