### PR TITLE
fix: add pagination to AirflowAPI and state filter

### DIFF
--- a/maintenance/dag_clean_logs_and_runs.py
+++ b/maintenance/dag_clean_logs_and_runs.py
@@ -16,6 +16,7 @@ from datagouvfr_data_pipelines.utils.airflow import AirflowAPI
 
 CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 nb_days_to_keep = 60
+PAGE_SIZE = 100
 
 
 def get_directory_size(directory):
@@ -67,28 +68,49 @@ def delete_old_logs_and_directories(**context):
 def delete_old_runs():
     """
     Query and delete runs older than the threshold date (2 months ago).
+    Paginates through all matching runs to ensure none are missed.
     """
 
     oldest_run_date = datetime.now(tz=timezone.utc) - timedelta(days=nb_days_to_keep)
+    logging.info(f"Deleting runs with end_date <= {oldest_run_date}")
 
     with AirflowAPI(conn_name=CONN_NAME).client as client:
         try:
-            logging.info("DEBUG: connected to Airflow Client")
             api = dag_run_api.DagRunApi(client)
-            logging.info(f"DEBUG: oldest_run_date type: {type(oldest_run_date)}")
-            logging.info(f"DEBUG: oldest_run_date : {oldest_run_date}")
-            logging.info(f"DEBUG: get_dag_runs ALL : {api.get_dag_runs(dag_id="~")}")
-            logging.info(f"DEBUG: DagRunAPI Client : {api}")
-            runs = api.get_dag_runs(
-                dag_id="~", start_date_lte=oldest_run_date, end_date_lte=oldest_run_date
-            )  # All DAGs run older than the threshold
-            logging.info(f"DEBUG: Runs : {runs}")
-            for run in runs.dag_runs:
-                logging.info(f"DEBUG: Loop on runs, iteration on run : {run}")
-                logging.info(f"DEBUG: dag_id {run.dag_id}, dag_run_id {run.dag_run_id}")
-                dag_id = run.dag_id
-                logging.info(f"Deleting run: dag_id={dag_id}, end_date={run.end_date}")
-                api.delete_dag_run(dag_id=dag_id, dag_run_id=run.dag_run_id)
+            offset = 0
+            total_deleted = 0
+
+            while True:
+                runs = api.get_dag_runs(
+                    dag_id="~",
+                    state=[
+                        "success",
+                        "failed",
+                    ],  # Filter out ongoing DAGs without end_date
+                    end_date_lte=oldest_run_date,
+                    limit=PAGE_SIZE,
+                    offset=offset,
+                )
+                logging.info(
+                    f"Page offset={offset}: {len(runs.dag_runs)} run(s) "
+                    f"(total matching: {runs.total_entries})"
+                )
+
+                if not runs.dag_runs:
+                    break
+
+                for run in runs.dag_runs:
+                    logging.info(
+                        f"Deleting run: dag_id={run.dag_id}, dag_run_id={run.dag_run_id}, end_date={run.end_date}"
+                    )
+                    api.delete_dag_run(dag_id=run.dag_id, dag_run_id=run.dag_run_id)
+                    total_deleted += 1
+
+                offset += len(runs.dag_runs)
+                if offset >= runs.total_entries:
+                    break
+
+            logging.info(f"Done: {total_deleted} run(s) deleted.")
         except Exception as e:
             logging.error(f"Error deleting old runs: {str(e)}")
 

--- a/maintenance/dag_clean_logs_and_runs.py
+++ b/maintenance/dag_clean_logs_and_runs.py
@@ -16,7 +16,6 @@ from datagouvfr_data_pipelines.utils.airflow import AirflowAPI
 
 CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 nb_days_to_keep = 60
-PAGE_SIZE = 100
 
 
 def get_directory_size(directory):
@@ -68,7 +67,6 @@ def delete_old_logs_and_directories(**context):
 def delete_old_runs():
     """
     Query and delete runs older than the threshold date (2 months ago).
-    Paginates through all matching runs to ensure none are missed.
     """
 
     oldest_run_date = datetime.now(tz=timezone.utc) - timedelta(days=nb_days_to_keep)
@@ -77,40 +75,23 @@ def delete_old_runs():
     with AirflowAPI(conn_name=CONN_NAME).client as client:
         try:
             api = dag_run_api.DagRunApi(client)
-            offset = 0
-            total_deleted = 0
 
-            while True:
-                runs = api.get_dag_runs(
-                    dag_id="~",
-                    state=[
-                        "success",
-                        "failed",
-                    ],  # Filter out ongoing DAGs without end_date
-                    end_date_lte=oldest_run_date,
-                    limit=PAGE_SIZE,
-                    offset=offset,
-                )
+            old_runs = AirflowAPI.paginate(
+                api.get_dag_runs,
+                "dag_runs",
+                dag_id="~",
+                state=["success", "failed"],  # exclude queued/running (no end_date)
+                end_date_lte=oldest_run_date,
+            )
+            logging.info(f"{len(old_runs)} run(s) to delete.")
+
+            for run in old_runs:
                 logging.info(
-                    f"Page offset={offset}: {len(runs.dag_runs)} run(s) "
-                    f"(total matching: {runs.total_entries})"
+                    f"Deleting run: dag_id={run.dag_id}, dag_run_id={run.dag_run_id}, end_date={run.end_date}"
                 )
+                api.delete_dag_run(dag_id=run.dag_id, dag_run_id=run.dag_run_id)
 
-                if not runs.dag_runs:
-                    break
-
-                for run in runs.dag_runs:
-                    logging.info(
-                        f"Deleting run: dag_id={run.dag_id}, dag_run_id={run.dag_run_id}, end_date={run.end_date}"
-                    )
-                    api.delete_dag_run(dag_id=run.dag_id, dag_run_id=run.dag_run_id)
-                    total_deleted += 1
-
-                offset += len(runs.dag_runs)
-                if offset >= runs.total_entries:
-                    break
-
-            logging.info(f"Done: {total_deleted} run(s) deleted.")
+            logging.info(f"Done: {len(old_runs)} run(s) deleted.")
         except Exception as e:
             logging.error(f"Error deleting old runs: {str(e)}")
 

--- a/meta/task_functions.py
+++ b/meta/task_functions.py
@@ -29,7 +29,7 @@ with open(f"{AIRFLOW_DAG_HOME}datagouvfr_data_pipelines/meta/config.json", "r") 
 
 
 def get_ids(config: dict, api: dag_api.DAGApi) -> dict[str, str]:
-    dags = api.get_dags().dags
+    dags = AirflowAPI.paginate(api.get_dags, "dags")
     ids = {}
     for raw_id, included in config.items():
         if not included:
@@ -67,25 +67,28 @@ def monitor_dags(
                 date_dt = date.replace(
                     tzinfo=timezone.utc
                 )  # The server needs a timezone-aware datetime or it throws a 500 error
-                dag_runs = dag_run_api_client.get_dag_runs(
+                dag_runs = AirflowAPI.paginate(
+                    dag_run_api_client.get_dag_runs,
+                    "dag_runs",
                     dag_id=dag_id,
-                    end_date_gte=date_dt,  # Does not filter out currently running DAGs
-                ).dag_runs
+                    end_date_gte=date_dt,
+                    state=["success", "failed"],  # exclude queued/running (no end_date)
+                )
             except NotFoundException:
                 dags_not_found.append(dag_id)
                 continue  # Raise an error only at the end to avoid skipping the rest of DAGs
             for dag_run in dag_runs:
                 start_date, end_date = dag_run.start_date, dag_run.end_date
-                if not end_date:
-                    continue  # Skipping currently running DAGs here
                 status = dag_run.state
                 if status != State.SUCCESS:
                     task_instance_api_client = task_instance_api.TaskInstanceApi(client)
-                    failed_task_instances = task_instance_api_client.get_task_instances(
+                    failed_task_instances = AirflowAPI.paginate(
+                        task_instance_api_client.get_task_instances,
+                        "task_instances",
                         dag_id=dag_run.dag_id,
                         dag_run_id=dag_run.dag_run_id,
                         state=[State.FAILED],
-                    ).task_instances
+                    )
                     todays_runs[dag_id][end_date] = {
                         "success": False,
                         "status": status,

--- a/utils/airflow.py
+++ b/utils/airflow.py
@@ -58,3 +58,26 @@ class AirflowAPI:
 
         # Instance of the API client to use as a context
         self.client = airflow_client.client.ApiClient(configuration)
+
+    @staticmethod
+    def paginate(api_call, result_attr: str, page_size: int = 100, **kwargs):
+        """Paginate through all results of an Airflow API list call.
+
+        :param api_call: bound API method to call (e.g. dag_api.get_dags)
+        :param result_attr: name of the list attribute on the response object
+                            ('dags', 'dag_runs', 'task_instances', ...)
+        :param page_size: number of items to fetch per request (default 100 to avoid overload)
+        :param kwargs: extra keyword arguments related to the bound API method
+                            ('end_date_lte', 'state', ...)
+        :return: flat list of all items across pages
+        """
+        all_items = []
+        offset = 0
+        while True:
+            response = api_call(limit=page_size, offset=offset, **kwargs)
+            items = getattr(response, result_attr)
+            all_items.extend(items)
+            offset += len(items)
+            if not items or offset >= response.total_entries:
+                break
+        return all_items


### PR DESCRIPTION
**Issues:**
1. It wasn't shared explicitly in the apache-airflow-client that the client itself also requires pagination (like the API)
2. The client to get DagRuns doesn't filter out runs without end_date when filtering on it (like `end_date_lte`)

**Solutions:**
1. A pagination method has been added to AirflowAPI so it can be shared across DAGs using it
2. A filter on `state` has been added to ensure no running nor queued runs are returned

Both fix have been made to Meta and Maintenance DAGs.