### PR TITLE
fix: dataset deces by-pass update check when manual

### DIFF
--- a/data_processing/insee/deces/config.json
+++ b/data_processing/insee/deces/config.json
@@ -1,8 +1,8 @@
 {
     "deces_csv": {
         "dev": {
-            "dataset_id": "66ba02e01af9c6b5cb8eb958",
-            "resource_id": "4675ccca-f67f-4a7e-bf81-066b1c517b8f"
+            "dataset_id": "66d997ba09e4429d7f846249",
+            "resource_id": "c75fc1d6-a6ab-496b-962d-e12b9480ed41"
         },
         "prod": {
             "dataset_id": "66d997ba09e4429d7f846249",
@@ -11,8 +11,8 @@
     },
     "deces_parquet": {
         "dev": {
-            "dataset_id": "66ba02e01af9c6b5cb8eb958",
-            "resource_id": "2cc21fbb-f77e-4956-abe2-08c5c0441612"
+            "dataset_id": "66d997ba09e4429d7f846249",
+            "resource_id": "d7aed239-8dc1-46dd-bc66-3d18097cb7ea"
         },
         "prod": {
             "dataset_id": "66d997ba09e4429d7f846249",

--- a/data_processing/insee/deces/task_functions.py
+++ b/data_processing/insee/deces/task_functions.py
@@ -24,11 +24,17 @@ from datagouvfr_data_pipelines.utils.utils import MOIS_FR
 
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}deces/"
+CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}insee/deces/config.json") as fp:
     config = json.load(fp)
 
 
-def check_if_modif():
+def check_if_modif(task_instance):
+    # Note : tried to get state.SKIPPED but next steps states are cleared while re-running,
+    # so falled back to manual run detection
+    if str(task_instance.run_id).startswith("manual"):
+        logging.info("Manual rerun detected, bypassing short-circuit.")
+        return True
     return local_client.resource(
         id=config["deces_csv"][AIRFLOW_ENV]["resource_id"],
     ).check_if_more_recent_update(dataset_id="5de8f397634f4164071119c5")

--- a/data_processing/insee/deces/task_functions.py
+++ b/data_processing/insee/deces/task_functions.py
@@ -24,7 +24,6 @@ from datagouvfr_data_pipelines.utils.utils import MOIS_FR
 
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}deces/"
-CONN_NAME = "HTTP_WORKFLOWS_INFRA_DATA_GOUV_FR"
 with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}insee/deces/config.json") as fp:
     config = json.load(fp)
 


### PR DESCRIPTION
By-pass update check on the source dataset when manual re-run, to be able to fix errors in the generated Data Gouv dataset even when the source dataset wasn't updated.