### PR TITLE
feat(geozones): rebuild parents/ancestors hierarchy from INSEE relations

### DIFF
--- a/data_processing/geozones/task_functions.py
+++ b/data_processing/geozones/task_functions.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import os
+from collections import defaultdict
 from datetime import datetime
 from io import BytesIO
 from urllib.parse import quote_plus, urlencode
@@ -37,9 +39,133 @@ levels_file = File(
 )
 
 
+def query_insee_sparql(query: str) -> bytes:
+    """Run a SPARQL query against the INSEE endpoint and return the CSV payload."""
+    endpoint = "https://rdf.insee.fr/sparql?query="
+    params = {"format": "application/csv;grid=true"}
+    url = endpoint + quote_plus(query, safe="*") + "&" + urlencode(params)
+    logging.info("Querying INSEE SPARQL endpoint: %s", url)
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.content
+
+
+def build_geozones_hierarchy(map_type: dict, exported_ids: set) -> tuple[dict, dict]:
+    """
+    Reconstruct, for every French zone, its parents and its full set of ancestors,
+    from the INSEE "subdivisionDirecteDe" relations.
+
+    Returns two dicts keyed by geozone id (e.g. "fr:commune:75056"):
+      - parents: the closest parent ids that are present in the export (e.g.
+        department + EPCI of a commune, or its commune for a delegated commune).
+        Intermediate zones filtered out of the export (typically départemental
+        arrondissements) are skipped, so a commune still exposes its department
+        even when INSEE only links it to the department through such an
+        arrondissement.
+      - ancestors: every ancestor id, transitively.
+
+    Both lists are restricted to zones actually present in the export
+    (``exported_ids``) so we never reference a filtered-out zone, and "country:fr"
+    is added as a top-level ancestor of every French zone. Statistical zonings
+    (unité urbaine, aire d'attraction...) and suppressed (historical) zones are
+    excluded directly in the SPARQL query.
+
+    Descendants are intentionally not computed here: they are obtained downstream
+    by a reverse lookup on ``ancestors``.
+    """
+    child_types = ", ".join(f"igeo:{insee_type}" for insee_type in map_type if insee_type != "Etat")
+    query = f"""PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX igeo:<http://rdf.insee.fr/def/geo#>
+
+    SELECT ?childType ?childCode ?parentType ?parentCode
+    WHERE {{
+        ?child igeo:subdivisionDirecteDe ?parent .
+        ?child rdf:type ?ct ; igeo:codeINSEE ?childCode .
+        ?parent rdf:type ?pt ; igeo:codeINSEE ?parentCode .
+        BIND(REPLACE(STR(?ct), "http://rdf.insee.fr/def/geo#", "") AS ?childType)
+        BIND(REPLACE(STR(?pt), "http://rdf.insee.fr/def/geo#", "") AS ?parentType)
+        FILTER(?ct IN ({child_types}))
+        FILTER(?pt IN (igeo:Region, igeo:Departement, igeo:CollectiviteDOutreMer,
+                       igeo:Intercommunalite, igeo:Arrondissement, igeo:Commune))
+        FILTER NOT EXISTS {{ ?evt_parent igeo:suppression ?parent }}
+        FILTER NOT EXISTS {{ ?evt_child igeo:suppression ?child }}
+    }}"""
+    edges = pd.read_csv(BytesIO(query_insee_sparql(query)), dtype=str)
+
+    expected_columns = {"childType", "childCode", "parentType", "parentCode"}
+    missing_columns = expected_columns - set(edges.columns)
+    if missing_columns:
+        raise ValueError(
+            f"Unexpected INSEE SPARQL response, missing columns: {sorted(missing_columns)}"
+        )
+    if edges.empty:
+        raise ValueError(
+            "INSEE SPARQL returned no subdivision relation; aborting so we never "
+            "publish a geozones export without any hierarchy."
+        )
+
+    def to_geoid(insee_type, code):
+        level = map_type.get(insee_type)
+        if level is None or not isinstance(code, str):
+            return None
+        return f"{level}:{code}"
+
+    direct_parents = defaultdict(set)
+    for child_type, child_code, parent_type, parent_code in zip(
+        edges["childType"], edges["childCode"], edges["parentType"], edges["parentCode"]
+    ):
+        child = to_geoid(child_type, child_code)
+        parent = to_geoid(parent_type, parent_code)
+        if child and parent and child != parent:
+            direct_parents[child].add(parent)
+
+    ancestors_cache = {}
+
+    def ancestors_of(geoid, visiting):
+        if geoid in ancestors_cache:
+            return ancestors_cache[geoid]
+        result = set()
+        for parent in direct_parents.get(geoid, ()):
+            if parent in visiting:
+                continue  # skip back-edge: a zone can never be its own ancestor
+            result.add(parent)
+            result |= ancestors_of(parent, visiting | {geoid})
+        ancestors_cache[geoid] = result
+        return result
+
+    parents_cache = {}
+
+    def closest_exported_parents(geoid, visiting):
+        """Direct parents present in the export, climbing over filtered-out ones."""
+        if geoid in parents_cache:
+            return parents_cache[geoid]
+        result = set()
+        for parent in direct_parents.get(geoid, ()):
+            if parent in visiting:
+                continue
+            if parent in exported_ids:
+                result.add(parent)
+            else:
+                result |= closest_exported_parents(parent, visiting | {geoid})
+        parents_cache[geoid] = result
+        return result
+
+    has_country = "country:fr" in exported_ids
+    parents = {}
+    ancestors = {}
+    for geoid in exported_ids:
+        if not geoid or not geoid.startswith("fr:"):
+            continue
+        zone_ancestors = ancestors_of(geoid, frozenset()) & exported_ids
+        if has_country:
+            zone_ancestors.add("country:fr")
+        ancestors[geoid] = sorted(zone_ancestors)
+        parents[geoid] = sorted(closest_exported_parents(geoid, frozenset()))
+    return parents, ancestors
+
+
 @task()
 def download_and_process_geozones():
-    endpoint = "https://rdf.insee.fr/sparql?query="
     query = """PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX rdfschema:<http://www.w3.org/2000/01/rdf-schema#>
     PREFIX igeo:<http://rdf.insee.fr/def/geo#>
@@ -49,20 +175,15 @@ def download_and_process_geozones():
         ?zone rdf:type ?territory .
         ?zone igeo:nom ?nom .
         ?zone igeo:codeINSEE ?codeINSEE .
-        OPTIONAL {
-            ?zone igeo:nomSansArticle ?nomSansArticle .
-            ?zone igeo:codeArticle ?codeArticle .
-            ?suppression_evt igeo:suppression ?zone .
-        }
+        # Each attribute is fetched in its own OPTIONAL: grouping them means the
+        # whole block only binds when *all* match, which (a) dropped nomSansArticle
+        # /codeArticle for every non-suppressed zone and (b) missed the suppression
+        # of zones lacking those attributes, mislabelling them as not deleted.
+        OPTIONAL { ?zone igeo:nomSansArticle ?nomSansArticle . }
+        OPTIONAL { ?zone igeo:codeArticle ?codeArticle . }
+        OPTIONAL { ?suppression_evt igeo:suppression ?zone . }
     }"""
-    params = {
-        "format": "application/csv;grid=true",
-    }
-    url = endpoint + quote_plus(query, safe="*") + "&" + urlencode(params)
-    print(url)
-    r = requests.get(url)
-    bytes_io = BytesIO(r.content)
-    df = pd.read_csv(bytes_io)
+    df = pd.read_csv(BytesIO(query_insee_sparql(query)))
     df["type"] = df["territory"].apply(lambda x: x.split("#")[1])
     df["is_deleted"] = df["suppression_evt"].apply(lambda s: isinstance(s, str))
     for c in df.columns:
@@ -95,11 +216,15 @@ def download_and_process_geozones():
     df = df.loc[df["level"] != "country"]
 
     # get countries (with ISO alpha 2 code) from another source
+    # keep_default_na=False: Namibia's ISO alpha-2 code is "NA", which pandas would
+    # otherwise read as NaN, leaving the country without a codeINSEE/_id.
     countries = pd.read_csv(
         "https://www.data.gouv.fr/api/1/datasets/r/2b38f28d-15e7-4f0c-b61d-6ca1d9b1cfa2",
         sep=";",
         encoding="cp1252",
         dtype=str,
+        keep_default_na=False,
+        na_values=[""],
     )
     countries = countries.loc[countries["SOUVERAIN"] == "O"]
     countries["uri"] = countries["CODE_COG"].apply(
@@ -203,6 +328,16 @@ def download_and_process_geozones():
         for c in geoz.keys():
             if geoz[c] == "nan":
                 geoz[c] = None
+
+    # Enrich each French zone with its hierarchy (direct parents + full ancestors),
+    # rebuilt from INSEE subdivision relations. Only zones kept in the export are
+    # referenced, so we never point to a filtered-out zone.
+    exported_ids = {geoz["_id"] for geoz in export}
+    parents_by_id, ancestors_by_id = build_geozones_hierarchy(map_type, exported_ids)
+    for geoz in export:
+        geoz["parents"] = parents_by_id.get(geoz["_id"], [])
+        geoz["ancestors"] = ancestors_by_id.get(geoz["_id"], [])
+
     os.mkdir(TMP_FOLDER)
     with open(geozones_file.full_source_path, "w", encoding="utf8") as f:
         json.dump(export, f, ensure_ascii=False, indent=4)

--- a/data_processing/geozones/task_functions.py
+++ b/data_processing/geozones/task_functions.py
@@ -64,14 +64,25 @@ def build_geozones_hierarchy(map_type: dict, exported_ids: set) -> tuple[dict, d
         arrondissement.
       - ancestors: every ancestor id, transitively.
 
+    Why both, even though parents is always a subset of ancestors? They answer
+    different questions, and we denormalize on purpose because this export is a
+    reference dataset read far more often than it is regenerated (~once a year):
+      - parents is the minimal navigation edge (breadcrumb, "one level up"). It is
+        also the only field that keeps the *direct* relation and a zone's several
+        distinct parent branches (a commune belongs both to a department and to an
+        EPCI); ancestors flattens those together and loses that distinction.
+      - ancestors is the flattened transitive closure, so a consumer can answer
+        "is X inside Y?" with a single O(1) membership test (``Y in X.ancestors``)
+        instead of walking the graph. Crucially, it is what lets descendants be
+        derived downstream by a reverse lookup ("all communes of region 27" =
+        every zone whose ancestors contains "fr:region:27"), which is why we do
+        not compute descendants here.
+
     Both lists are restricted to zones actually present in the export
     (``exported_ids``) so we never reference a filtered-out zone, and "country:fr"
     is added as a top-level ancestor of every French zone. Statistical zonings
     (unité urbaine, aire d'attraction...) and suppressed (historical) zones are
     excluded directly in the SPARQL query.
-
-    Descendants are intentionally not computed here: they are obtained downstream
-    by a reverse lookup on ``ancestors``.
     """
     child_types = ", ".join(
         f"igeo:{insee_type}" for insee_type in map_type if insee_type != "Etat"

--- a/data_processing/geozones/task_functions.py
+++ b/data_processing/geozones/task_functions.py
@@ -73,7 +73,9 @@ def build_geozones_hierarchy(map_type: dict, exported_ids: set) -> tuple[dict, d
     Descendants are intentionally not computed here: they are obtained downstream
     by a reverse lookup on ``ancestors``.
     """
-    child_types = ", ".join(f"igeo:{insee_type}" for insee_type in map_type if insee_type != "Etat")
+    child_types = ", ".join(
+        f"igeo:{insee_type}" for insee_type in map_type if insee_type != "Etat"
+    )
     query = f"""PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX igeo:<http://rdf.insee.fr/def/geo#>
 


### PR DESCRIPTION
## Rebuild geozones parents/ancestors hierarchy from INSEE

### What & why
The geozones export now ships a full administrative hierarchy for every zone, and fixes several long-standing data defects surfaced while validating the export against the live INSEE source.

### New features
- **`parents` + `ancestors` on every record** — rebuilt from INSEE `subdivisionDirecteDe` relations. Parents climb over zones excluded from the export (e.g. départemental arrondissements), so a commune still exposes its department + EPCI; `ancestors` lists the full transitive chain up to `country:fr`.

### Bug fixes
- **Missing `nomSansArticle` / `codeArticle`** — the grouped `OPTIONAL` block only bound when *all* attributes matched, silently dropping these fields and mislabelling some deletions. Now split into independent `OPTIONAL`s.
- **Namibia had no id** — its ISO code `NA` was parsed by pandas as `NaN`, leaving `_id`/`codeINSEE` null. Read the countries CSV with `keep_default_na=False` → valid `country:na`.
- **Robustness** — `raise_for_status()` on INSEE calls, plus guards that abort if the hierarchy query returns no rows / unexpected columns, and a null-`_id` guard.

### Impact on the exported file (validated against prod 2024)
|                 | Prod 2024 | This PR (2026)                |
| --------------- | --------- | ----------------------------- |
| Records         | 53,752    | 54,780                        |
| Keys per record | 9         | 11 (`+parents`, `+ancestors`) |

**2026 data refresh** (vs prod): **+667** new ids (620 communes, 45 departments/overseas, 2 EPCI), **0** zones lost · 149 renames · 186 deletion-status changes · 99 type changes.

**Specific corrections** (on records common to both):
- `nomSansArticle`: **39,014 null → 0** (~36k names recovered)
- `codeArticle`: ~35,900 recovered
- Records with null `_id`: **1 → 0** (Namibia)
- `parents`/`ancestors` populated for all active zones; deleted zones correctly have no parents.