### PR TITLE
feat(finess): add manual force rebuild trigger

### DIFF
--- a/data_processing/insee/deces/dag.py
+++ b/data_processing/insee/deces/dag.py
@@ -10,7 +10,10 @@ from datagouvfr_data_pipelines.data_processing.insee.deces.task_functions import
     publish_on_datagouv,
     send_to_s3,
 )
-from datagouvfr_data_pipelines.utils.tasks import clean_up_folder
+from datagouvfr_data_pipelines.utils.tasks import (
+    clean_up_folder,
+    force_rebuild_params,
+)
 
 default_args = {
     "retries": 5,
@@ -27,6 +30,7 @@ with DAG(
     tags=["deces", "consolidation", "datagouv"],
     catchup=False,
     default_args=default_args,
+    params=force_rebuild_params(),
 ):
     (
         clean_up_folder(TMP_FOLDER, recreate=True)

--- a/data_processing/insee/deces/task_functions.py
+++ b/data_processing/insee/deces/task_functions.py
@@ -19,6 +19,7 @@ from datagouvfr_data_pipelines.utils.datagouv import (
 )
 from datagouvfr_data_pipelines.utils.filesystem import File
 from datagouvfr_data_pipelines.utils.s3 import S3Client
+from datagouvfr_data_pipelines.utils.tasks import force_rebuild_requested
 from datagouvfr_data_pipelines.utils.tchap import send_message
 from datagouvfr_data_pipelines.utils.utils import MOIS_FR
 
@@ -28,11 +29,8 @@ with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}insee/deces/config.json") as fp:
     config = json.load(fp)
 
 
-def check_if_modif(task_instance):
-    # Note : tried to get state.SKIPPED but next steps states are cleared while re-running,
-    # so falled back to manual run detection
-    if str(task_instance.run_id).startswith("manual"):
-        logging.info("Manual rerun detected, bypassing short-circuit.")
+def check_if_modif(dag_run=None):
+    if force_rebuild_requested(dag_run):
         return True
     return local_client.resource(
         id=config["deces_csv"][AIRFLOW_ENV]["resource_id"],

--- a/data_processing/rna/dag.py
+++ b/data_processing/rna/dag.py
@@ -10,7 +10,10 @@ from datagouvfr_data_pipelines.data_processing.rna.task_functions import (
     publish_on_datagouv,
     send_rna_to_s3,
 )
-from datagouvfr_data_pipelines.utils.tasks import clean_up_folder
+from datagouvfr_data_pipelines.utils.tasks import (
+    clean_up_folder,
+    force_rebuild_params,
+)
 
 with DAG(
     dag_id="data_processing_rna",
@@ -20,6 +23,7 @@ with DAG(
     catchup=False,
     dagrun_timeout=timedelta(minutes=240),
     tags=["data_processing", "rna", "association"],
+    params=force_rebuild_params(),
 ):
     clean_previous_outputs = clean_up_folder(TMP_FOLDER, recreate=True)
     clean_up = clean_up_folder(TMP_FOLDER)

--- a/data_processing/rna/task_functions.py
+++ b/data_processing/rna/task_functions.py
@@ -16,6 +16,7 @@ from datagouvfr_data_pipelines.utils.conversions import csv_to_parquet
 from datagouvfr_data_pipelines.utils.datagouv import local_client
 from datagouvfr_data_pipelines.utils.filesystem import File
 from datagouvfr_data_pipelines.utils.s3 import S3Client
+from datagouvfr_data_pipelines.utils.tasks import force_rebuild_requested
 from datagouvfr_data_pipelines.utils.tchap import send_message
 from datagouvfr_data_pipelines.utils.utils import MOIS_FR
 from unidecode import unidecode
@@ -26,7 +27,9 @@ with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}rna/config.json") as fp:
     config = json.load(fp)
 
 
-def check_if_modif():
+def check_if_modif(dag_run=None):
+    if force_rebuild_requested(dag_run):
+        return True
     return local_client.resource(
         id=config["import"]["csv"][AIRFLOW_ENV]["resource_id"]
     ).check_if_more_recent_update(dataset_id="58e53811c751df03df38f42d")

--- a/data_processing/sante/controle_sanitaire_eau/dag.py
+++ b/data_processing/sante/controle_sanitaire_eau/dag.py
@@ -11,7 +11,10 @@ from datagouvfr_data_pipelines.data_processing.sante.controle_sanitaire_eau.task
     publish_on_datagouv,
     send_to_s3,
 )
-from datagouvfr_data_pipelines.utils.tasks import clean_up_folder
+from datagouvfr_data_pipelines.utils.tasks import (
+    clean_up_folder,
+    force_rebuild_params,
+)
 
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 
@@ -28,6 +31,7 @@ with DAG(
     dagrun_timeout=timedelta(minutes=240),
     tags=["data_processing", "sante", "eau"],
     default_args=default_args,
+    params=force_rebuild_params(),
 ):
     _process_data = process_data()
     clean_up = clean_up_folder(TMP_FOLDER)

--- a/data_processing/sante/controle_sanitaire_eau/task_functions.py
+++ b/data_processing/sante/controle_sanitaire_eau/task_functions.py
@@ -17,6 +17,7 @@ from datagouvfr_data_pipelines.utils.conversions import (
 from datagouvfr_data_pipelines.utils.datagouv import local_client
 from datagouvfr_data_pipelines.utils.filesystem import File
 from datagouvfr_data_pipelines.utils.s3 import S3Client
+from datagouvfr_data_pipelines.utils.tasks import force_rebuild_requested
 from datagouvfr_data_pipelines.utils.tchap import send_message
 
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
@@ -29,7 +30,9 @@ config = {
 }
 
 
-def check_if_modif():
+def check_if_modif(dag_run=None):
+    if force_rebuild_requested(dag_run):
+        return True
     return local_client.resource(id=config["RESULT"]).check_if_more_recent_update(
         dataset_id="5cf8d9ed8b4c4110294c841d"
     )

--- a/data_processing/sante/finess/dag.py
+++ b/data_processing/sante/finess/dag.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow.providers.standard.operators.python import ShortCircuitOperator
-from airflow.sdk import DAG
+from airflow.sdk import DAG, Param
 from datagouvfr_data_pipelines.data_processing.sante.finess.task_functions import (
     TMP_FOLDER,
     build_and_save,
@@ -27,6 +27,13 @@ with DAG(
     dagrun_timeout=timedelta(minutes=240),
     tags=["data_processing", "sante", "finess"],
     default_args=default_args,
+    params={
+        "force_rebuild": Param(
+            False,
+            type="boolean",
+            description="Reconstruit et pousse sur datagouv les fichiers FINESS quelque soit le résultat des test check_if_modif.",
+        ),
+    },
 ):
     clean_previous_outputs = clean_up_folder(TMP_FOLDER, recreate=True)
     clean_up = clean_up_folder(

--- a/data_processing/sante/finess/dag.py
+++ b/data_processing/sante/finess/dag.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow.providers.standard.operators.python import ShortCircuitOperator
-from airflow.sdk import DAG, Param
+from airflow.sdk import DAG
 from datagouvfr_data_pipelines.data_processing.sante.finess.task_functions import (
     TMP_FOLDER,
     build_and_save,
@@ -12,7 +12,10 @@ from datagouvfr_data_pipelines.data_processing.sante.finess.task_functions impor
     publish_on_datagouv,
     send_to_s3,
 )
-from datagouvfr_data_pipelines.utils.tasks import clean_up_folder
+from datagouvfr_data_pipelines.utils.tasks import (
+    clean_up_folder,
+    force_rebuild_params,
+)
 
 default_args = {
     "retries": 5,
@@ -27,13 +30,9 @@ with DAG(
     dagrun_timeout=timedelta(minutes=240),
     tags=["data_processing", "sante", "finess"],
     default_args=default_args,
-    params={
-        "force_rebuild": Param(
-            False,
-            type="boolean",
-            description="Reconstruit et pousse sur datagouv les fichiers FINESS quelque soit le résultat des test check_if_modif.",
-        ),
-    },
+    params=force_rebuild_params(
+        "Reconstruit et pousse sur datagouv les fichiers FINESS quelque soit le résultat des test check_if_modif."
+    ),
 ):
     clean_previous_outputs = clean_up_folder(TMP_FOLDER, recreate=True)
     clean_up = clean_up_folder(

--- a/data_processing/sante/finess/task_functions.py
+++ b/data_processing/sante/finess/task_functions.py
@@ -26,7 +26,11 @@ with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}sante/finess/config.json") as fp:
     config = json.load(fp)
 
 
-def check_if_modif(scope: str):
+def check_if_modif(scope: str, dag_run=None):
+    conf = getattr(dag_run, "conf", None) or {}
+    if conf.get("force_rebuild"):
+        logging.info(f"force_rebuild=True for {scope}, bypassing short-circuit.")
+        return True
     return prod_client.resource(
         id=config[scope]["prod"]["resource_id"]
     ).check_if_more_recent_update(

--- a/data_processing/sante/finess/task_functions.py
+++ b/data_processing/sante/finess/task_functions.py
@@ -17,6 +17,7 @@ from datagouvfr_data_pipelines.config import (
 from datagouvfr_data_pipelines.utils.datagouv import local_client, prod_client
 from datagouvfr_data_pipelines.utils.filesystem import File
 from datagouvfr_data_pipelines.utils.s3 import S3Client
+from datagouvfr_data_pipelines.utils.tasks import force_rebuild_requested
 from datagouvfr_data_pipelines.utils.tchap import send_message
 
 DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
@@ -27,9 +28,7 @@ with open(f"{AIRFLOW_DAG_HOME}{DAG_FOLDER}sante/finess/config.json") as fp:
 
 
 def check_if_modif(scope: str, dag_run=None):
-    conf = getattr(dag_run, "conf", None) or {}
-    if conf.get("force_rebuild"):
-        logging.info(f"force_rebuild=True for {scope}, bypassing short-circuit.")
+    if force_rebuild_requested(dag_run, context=scope):
         return True
     return prod_client.resource(
         id=config[scope]["prod"]["resource_id"]

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -1,4 +1,44 @@
+import logging
+
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk import Param
+
+FORCE_REBUILD = "force_rebuild"
+
+
+def force_rebuild_params(description: str | None = None) -> dict:
+    """
+    Ajoute le paramètre force_rebuild au DAG param.
+    Ce paramètre est ensuite utilisé par force_rebuild_requested() lorsqu'on veut
+    bypass des short-circuit.
+    Pour ajouter d'autres paramètres à un DAG utiliser le format suivant :
+    `params={...} | force_rebuild_params(),`
+
+    Args:
+        description(str, None); Optionnel. Description du bouton force_rebuild sur l'UI Airflow.
+    """
+    return {
+        FORCE_REBUILD: Param(
+            False,
+            type="boolean",
+            description=description
+            or "Reconstruit et pousse sur datagouv quelque soit le résultat du test check_if_modif.",
+        )
+    }
+
+
+def force_rebuild_requested(dag_run, context: str = "") -> bool:
+    """
+    Retourne vrai lorsqu'un DAG est lancé avec le paramètre `force_rebuild` à vrai.
+    Utile pour bypass des short-circuit.
+    Voire les fonction `check_if_modif()`.
+    """
+    conf = getattr(dag_run, "conf", None) or {}
+    if conf.get(FORCE_REBUILD):
+        suffix = f" for {context}" if context else ""
+        logging.info(f"force_rebuild=True{suffix}, bypassing short-circuit.")
+        return True
+    return False
 
 
 def clean_up_folder(folder: str, recreate: bool = False, **kwargs) -> BashOperator:


### PR DESCRIPTION
Sur le modèle de ce que @estellebertrand à fait pour `décès`, pouvoir trigger un rebuild complet des fichiers FINESS lors d'une exécution manuelle du DAG.
Ajoute aussi un paramètre pour offrir la possibilité en cas de manual trigger de bypass ou non les checks.

Ajoute aussi le paramètre aux fonctions `check_if_modif()` des DAGs RNA, sanitaire eau et décès.