### PR TITLE
ci: upgrade python to same version as prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   python-version:
     type: string
-    default: "3.10"
+    default: "3.12"
 
 jobs:
   lint:
@@ -19,6 +19,7 @@ jobs:
           command: |
             python -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
             pip install ruff>=0.11.2
             ruff --version
             ruff check .

--- a/.github/workflows/simplifions_tests.yml
+++ b/.github/workflows/simplifions_tests.yml
@@ -11,27 +11,27 @@ on:
 jobs:
   test-simplifions:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
-        
+        python-version: '3.12'
+
     - name: Create virtual environment
       run: |
         python3 -m venv venv
         source venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
-        
+
     - name: Install test dependencies
       run: |
         pip install -r verticales/simplifions/tests/test-requirements.txt
-        
+
     - name: Run simplifions tests
       run: |
         pytest verticales/simplifions/tests/ -s -v


### PR DESCRIPTION
Utilise Python 3.12 dans la CI comme en prod