### PR TITLE
fix: content file for csv upload to object storage

### DIFF
--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -33,20 +33,21 @@ class File:
             if not remote_source:
                 self.assert_file_exists(self.source_path, self.source_name)
                 if not content_type:
-                    # importing magic at module level triggers ctypes.find_library
-                    # (a subprocess call to ldconfig) at import time, which can hang
-                    # long enough to blow the Airflow DAG import timeout
-                    import magic
-
-                    self.content_type = (
+                    if source_name.endswith(".csv.gz"):
                         # csv.gz is not properly detected so we bypass
-                        "application/gzip"
-                        if source_name.endswith("csv.gz")
-                        else magic.from_file(
+                        self.content_type = "application/gzip"
+                    elif source_name.endswith(".csv"):
+                        # bypass since csv are converted to text/plain by magic
+                        self.content_type = "text/csv"
+                    else:
+                        # importing magic at module level triggers ctypes.find_library
+                        # (a subprocess call to ldconfig) at import time, which can hang
+                        # long enough to blow the Airflow DAG import timeout
+                        import magic
+                        self.content_type = magic.from_file(
                             self.source_path + self.source_name,
                             mime=True,
                         )
-                    )
 
     def __getitem__(self, item: str):
         return getattr(self, item)


### PR DESCRIPTION
`Content-Type=text/csv` est manquant pour plusieurs fichiers téléversés sur l'object storage.
Lorsqu'il n'est pas renseigné cela default à `text/plain` et les navigateurs affichent le fichier au lieu de le télécharger. Exemple :
https://www.data.gouv.fr/datasets/petitions-de-lassemblee-nationale?resource_id=c94c9dfe-23eb-45aa-acd1-7438c4e977db

Edit : la librairie `magic` galère avec les CSV. Elle n'arrive pas à les distinguer de fichiers textes. J'ai changé le code pour ajouter une autre exception à `File` pour respecter les changements fait par Thibaud.

Note : certains fichiers formations QUALIOPI sont encore un état instable avec `Content-Encoding=gzip`, cela sera résolu dans une autre PR.