### PR TITLE
fix: irve dag cloning

### DIFF
--- a/schema/irve/dag.py
+++ b/schema/irve/dag.py
@@ -53,10 +53,22 @@ with DAG(
     default_args=default_args,
 ):
     (
-        clean_up_folder(TMP_FOLDER.as_posix(), recreate=True)
-        >> BashOperator(
+        BashOperator(
             task_id="clone_dag_schema_repo",
-            bash_command=f"cd {TMP_FOLDER} && git clone {GIT_REPO} --depth 1 ",
+            # Recreating the folder before cloning to avoid stale data when a retry occurs
+            bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER} && cd {TMP_FOLDER} && timeout 300 git clone {GIT_REPO} --depth 1 ",
+            execution_timeout=timedelta(minutes=10),
+            env={
+                "GIT_SSH_COMMAND": (
+                    "ssh "
+                    # Fail instead of asking interactive questions and hagging indefinitely
+                    "-o BatchMode=yes "
+                    # Fail fast instead of hanging forever on a stalled SSH git clone
+                    # so Airflow retry can actually occur quickly
+                    "-o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+                ),
+            },
+            append_env=True,
         )
         >> get_all_irve_resources(
             tmp_path=TMP_FOLDER,

--- a/schema/irve/dag.py
+++ b/schema/irve/dag.py
@@ -88,9 +88,8 @@ with DAG(
             task_id="commit_changes",
             bash_command=(
                 f"cd {TMP_FOLDER.as_posix()}/schema.data.gouv.fr/ && git add config_consolidation.yml "
-                ' && git commit -m "Update config consolidation file - '
-                f"{datetime.today().strftime('%Y-%m-%d')}"
-                '" || echo "No changes to commit"'
+                ' && git commit -m "Update config consolidation file - {{ ds }}"'
+                ' || echo "No changes to commit"'
                 " && git push origin main"
             ),
         )

--- a/schema/irve/dag.py
+++ b/schema/irve/dag.py
@@ -61,8 +61,10 @@ with DAG(
             env={
                 "GIT_SSH_COMMAND": (
                     "ssh "
-                    # Fail instead of asking interactive questions and hagging indefinitely
-                    "-o BatchMode=yes "
+                    # # Fail instead of asking interactive questions and hagging indefinitely
+                    # "-o BatchMode=yes "
+                    # Temporary debug fix
+                    "-o StrictHostKeyChecking=accept-new "
                     # Fail fast instead of hanging forever on a stalled SSH git clone
                     # so Airflow retry can actually occur quickly
                     "-o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"


### PR DESCRIPTION
Je ne peux pas reproduire le bug localement car c'est dépendant d'un setup SSH propre au serveur de production.
À mon avis cela vient d'un prompt interactif de SSH du type "unknown host". Je n'ai pas accès au serveur de production pour vérifier. À valider avec quelqu'un qui a les accès au serveur.
Sinon ajouter `-o StrictHostKeyChecking=accept-new` mais il serait peut être préférable que cela soit géré côté infra pour que github.com soit pre-validé @jordanguedj ?

Cependant voici quelques améliorations : 

1. Warning banner

Il y a une grosse bannière de warning sur le DAG : `This Dag uses runtime-variable values in Dag construction.`

À la place d'utiliser `datetime` on peut utiliser les variables jinja de Airflow [tel que ici](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/operators.html#templating-conflicts-with-f-strings).

2. Erreur lors des retry

Tous les retry de la task `clone_dag_schema_repo` échouent avec [la même erreur](https://workflows.infra.data.gouv.fr/dags/irve_consolidation/runs/scheduled__2026-07-05T02:20:00+00:00/tasks/clone_dag_schema_repo?try_number=2) :
```bash
[2026-07-05 07:13:33] INFO - fatal: destination path 'schema.data.gouv.fr' already exists and is not an empty directory.
```

Il faut donc clean le dossier temporaire dans la même tâche que celle du clone,

3. Git clone qui ne fini jamais

Ajouter un fail fast au git clone afin que la task ne [prenne pas 2h50 pour retry](https://workflows.infra.data.gouv.fr/dags/irve_consolidation/runs/scheduled__2026-07-05T02:20:00+00:00/tasks/clone_dag_schema_repo?try_number=1) lorsque le git clone ne termine jamais.


