### PR TITLE
revert(irve): temporary ssh fix

### DIFF
--- a/schema/irve/dag.py
+++ b/schema/irve/dag.py
@@ -56,20 +56,8 @@ with DAG(
         BashOperator(
             task_id="clone_dag_schema_repo",
             # Recreating the folder before cloning to avoid stale data when a retry occurs
-            bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER} && cd {TMP_FOLDER} && timeout 300 git clone {GIT_REPO} --depth 1 ",
+            bash_command=f"rm -rf {TMP_FOLDER} && mkdir -p {TMP_FOLDER} && cd {TMP_FOLDER} && git clone {GIT_REPO} --depth 1 ",
             execution_timeout=timedelta(minutes=10),
-            env={
-                "GIT_SSH_COMMAND": (
-                    "ssh "
-                    # # Fail instead of asking interactive questions and hagging indefinitely
-                    # "-o BatchMode=yes "
-                    # Temporary debug fix
-                    "-o StrictHostKeyChecking=accept-new "
-                    # Fail fast instead of hanging forever on a stalled SSH git clone
-                    # so Airflow retry can actually occur quickly
-                    "-o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-                ),
-            },
             append_env=True,
         )
         >> get_all_irve_resources(


### PR DESCRIPTION
Problème infra et non ssh. Je laisse `execution_timeout=timedelta(minutes=10)` pour éviter que le DAG prenne 6h pour fail.