### PR TITLE
fix(meteo): temporary write to local /tmp instead of shared tmp volume

### DIFF
--- a/data_processing/meteo/ftp_processing/task_functions.py
+++ b/data_processing/meteo/ftp_processing/task_functions.py
@@ -11,7 +11,6 @@ import requests
 from airflow.sdk import task
 from datagouvfr_data_pipelines.config import (
     AIRFLOW_DAG_HOME,
-    AIRFLOW_DAG_TMP,
     AIRFLOW_ENV,
     SECRET_FTP_METEO_ADDRESS,
     SECRET_FTP_METEO_PASSWORD,
@@ -24,7 +23,7 @@ from datagouvfr_data_pipelines.utils.tchap import send_message
 from dateutil import parser
 
 ROOT_FOLDER = "datagouvfr_data_pipelines/data_processing/"
-TMP_FOLDER = f"{AIRFLOW_DAG_TMP}meteo_ftp/"
+TMP_FOLDER = "/tmp/meteo_ftp/"  # temporarily write to local /tmp instead of shared volume due to perf issues
 s3_folder = "data/synchro_ftp/"
 bucket = "meteofrance"
 with open(f"{AIRFLOW_DAG_HOME}{ROOT_FOLDER}meteo/config.json") as fp:

--- a/utils/filesystem.py
+++ b/utils/filesystem.py
@@ -44,6 +44,7 @@ class File:
                         # (a subprocess call to ldconfig) at import time, which can hang
                         # long enough to blow the Airflow DAG import timeout
                         import magic
+
                         self.content_type = magic.from_file(
                             self.source_path + self.source_name,
                             mime=True,


### PR DESCRIPTION
Hack to bypass shared volume perfs, should be reverted when fixed