### PR TITLE
fix(controle eau): increase DAG timeout

### DIFF
--- a/data_processing/sante/controle_sanitaire_eau/dag.py
+++ b/data_processing/sante/controle_sanitaire_eau/dag.py
@@ -28,7 +28,7 @@ with DAG(
     schedule="0 7 * * *",
     start_date=datetime(2024, 8, 10),
     catchup=False,
-    dagrun_timeout=timedelta(minutes=240),
+    dagrun_timeout=timedelta(minutes=300),
     tags=["data_processing", "sante", "eau"],
     default_args=default_args,
     params=force_rebuild_params(),


### PR DESCRIPTION
La task `process_data` du DAG de Controle Sanitaire de l'Eau [ne fail plus de manière spontanée comme avant](https://workflows.infra.data.gouv.fr/dags/data_processing_controle_sanitaire_eau/runs/scheduled__2026-07-06T05:00:00+00:00/tasks/process_data?try_number=4), [mais le DAG prend plus que la limite de 4h](https://workflows.infra.data.gouv.fr/dags/data_processing_controle_sanitaire_eau/runs/manual__2026-07-06T17:08:53.934568+00:00/tasks/process_data). La limite est augmentée à 5h, voyons voir si cela suffit.