### PR TITLE
fix(senat petition): make files public

### DIFF
--- a/data_processing/senat/petitions/task_functions.py
+++ b/data_processing/senat/petitions/task_functions.py
@@ -160,6 +160,7 @@ def send_petitions_to_s3():
             ),
         ],
         ignore_airflow_env=True,
+        is_public=True,
     )
 
 


### PR DESCRIPTION
Les fichiers poussés sur S3 ne sont pas publics, la PR ajoute le ACL public.

<img width="562" height="150" alt="image" src="https://github.com/user-attachments/assets/44f35ead-bfbb-46f0-bf88-5a8afd558009" />
