### PR TITLE
chore: set temp_directory in duckdb to geoparquet

### DIFF
--- a/utils/conversions.py
+++ b/utils/conversions.py
@@ -127,6 +127,7 @@ def csv_to_geoparquet(
         "SET threads TO 2;",
         "SET memory_limit = '6GB';",
         "SET max_temp_directory_size = '125GB';",
+        f"SET temp_directory = '{output_path}.tmp/';",
         query,
     ]
 


### PR DESCRIPTION
In order to prevent error such as `IOException: IO Error: Could not write file ".tmp/duckdb_temp_storage_DEFAULT-1.tmp": No space left on device`