### PR TITLE
fix: update dagrun timeout in dag.py

### DIFF
--- a/schema/website/dag.py
+++ b/schema/website/dag.py
@@ -30,8 +30,8 @@ with DAG(
     schedule="0 2 * * *",
     start_date=datetime(2024, 8, 10),
     dagrun_timeout=timedelta(
-        minutes=210
-    ),  # 2H timeout + 1H waiting between preprod and prod for update_news_feed task + 30min sleep fetching pages
+        minutes=420
+    ),  # TODO : temp. multiply by 2 to see if this works x 2H timeout + 1H waiting between preprod and prod for update_news_feed task + 30min sleep fetching pages
     tags=["schemas", "backend", "schema.data.gouv.fr"],
     catchup=False,
     default_args=default_args,


### PR DESCRIPTION
Increased dagrun timeout from 210 minutes to 420 minutes for testing.