### PR TITLE
fix: process empty day from matomo response

### DIFF
--- a/dgv/stats/task_functions.py
+++ b/dgv/stats/task_functions.py
@@ -66,7 +66,13 @@ def get_months(site_id, year):
     }
     r = requests.post("https://stats.data.gouv.fr/", data=params)
     r.raise_for_status()
-    df = pd.DataFrame(r.json()).transpose()
+    # Note: Matomo returns [] (not {}) for a day it has no archived data for
+    # We lost the data for 2026-08-31, which means this date has [] - we need to process it first
+    days = {
+        day: metrics if isinstance(metrics, dict) else {}
+        for day, metrics in r.json().items()
+    }
+    df = pd.DataFrame(days).transpose()
     return df
 
 


### PR DESCRIPTION
## Problem 

Matomo returns [] (not {}) for a day it has no archived data for.
We lost the data for 2026-08-31, which means this date has [] - we need to process it first
This lead to `ValueError: Mixing dicts with non-Series may lead to ambiguous ordering.`

## Solution

Casting first anything that isn't a dict as a dict