### PR TITLE
fix(dvf): compute stats for Paris, Lyon and Marseille

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,10 @@ jobs:
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install ruff>=0.11.2
+            # version alignée sur .pre-commit-config.yaml : sans borne haute, une
+            # nouvelle version de ruff élargit les règles par défaut et met la CI
+            # au rouge sur du code qui n'a pas bougé
+            pip install ruff==0.15.20
             ruff --version
             ruff check .
             ruff format --check .

--- a/data_processing/dvf/explore/task_functions.py
+++ b/data_processing/dvf/explore/task_functions.py
@@ -3,6 +3,7 @@ import glob
 import json
 import logging
 import os
+from collections.abc import Iterable
 from datetime import datetime
 from functools import reduce
 
@@ -29,6 +30,12 @@ DAG_FOLDER = "datagouvfr_data_pipelines/data_processing/"
 TMP_FOLDER = f"{AIRFLOW_DAG_TMP}dvf/"
 DPEDIR = f"{TMP_FOLDER}dpe/"
 schema = "dvf"
+
+# Dans DVF, les mutations de Paris, Lyon et Marseille portent le code de leur
+# arrondissement municipal (751xx, 693xx, 132xx) ; le code de la commune n'apparaît
+# jamais. Sans rattachement, ces trois villes sont les seules communes de France
+# sans aucune statistique. On indexe par préfixe d'arrondissement.
+COMMUNES_PLM = {"751": "75056", "693": "69123", "132": "13055"}
 
 
 def get_year_interval() -> tuple[int, int]:
@@ -412,6 +419,27 @@ def filter_communes(communes: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([unique_rows, duplicate_rows]).sort_index()
 
 
+def add_communes_plm(mutations: pd.DataFrame, echelles: Iterable[str]) -> pd.DataFrame:
+    """Rattache les mutations des arrondissements municipaux à leur commune.
+
+    Chaque mutation d'un arrondissement de Paris, Lyon ou Marseille est dupliquée
+    sous le code de sa commune, de sorte que les statistiques de ces villes soient
+    calculées sur leurs mutations et non agrégées depuis celles des arrondissements.
+    Les codes des autres échelles sont vidés sur ces doublons pour qu'ils ne soient
+    comptés qu'une fois par département, EPCI et section.
+    """
+    plm = pd.concat(
+        [
+            mutations.loc[
+                mutations["code_commune"].str.startswith(prefixe, na=False)
+            ].assign(code_commune=code_commune)
+            for prefixe, code_commune in COMMUNES_PLM.items()
+        ]
+    )
+    plm[[f"code_{e}" for e in echelles if e != "commune"]] = np.nan
+    return pd.concat([mutations, plm], ignore_index=True)
+
+
 @task()
 def process_dvf_stats() -> None:
     years = sorted(
@@ -528,6 +556,9 @@ def process_dvf_stats() -> None:
         logging.info(
             f"Après retrait des ventes sans prix au m² et valeurs aberrantes : {len(ventes_nodup)}"
         )
+        # seules les agrégations géographiques rattachent les arrondissements à leur
+        # commune ; les stats nationales restent calculées sur les mutations réelles
+        ventes_avec_plm = add_communes_plm(ventes_nodup, echelles_of_interest)
         export_intermediary = []
 
         # avoid unnecessary steps due to half years
@@ -541,7 +572,7 @@ def process_dvf_stats() -> None:
         for m in month_range:
             dfs_dict = {}
             for echelle in echelles_of_interest:
-                grouped = ventes_nodup.groupby(
+                grouped = ventes_avec_plm.groupby(
                     [f"code_{echelle}", "month", "type_local"]
                 )["prix_m2"]
 
@@ -591,8 +622,8 @@ def process_dvf_stats() -> None:
                 merged = pd.merge(merged, median_, on=[f"code_{echelle}"])
 
                 # appartement + maison
-                combined = ventes_nodup.loc[
-                    ventes_nodup["code_type_local"].isin([1, 2])
+                combined = ventes_avec_plm.loc[
+                    ventes_avec_plm["code_type_local"].isin([1, 2])
                 ].groupby([f"code_{echelle}", "month"])["prix_m2"]
 
                 nb = combined.count()
@@ -683,6 +714,7 @@ def process_dvf_stats() -> None:
         del export_intermediary
         del ventes
         del ventes_nodup
+        del ventes_avec_plm
         gc.collect()
         logging.info(f"Done with {year}")
 
@@ -1006,12 +1038,18 @@ def create_distribution_and_stats_whole_period() -> None:
     dvf = dvf[
         ["code_" + e for e in echelles_of_interest] + ["code_type_local", "prix_m2"]
     ]
+    # cf. process_dvf_stats : seules les agrégations géographiques rattachent les
+    # arrondissements à leur commune, les stats nationales portent sur dvf
+    dvf_avec_plm = add_communes_plm(dvf, echelles_of_interest)
     threshold = 100
     tranches = []
     stats_period = []
     for t in types_of_interest:
         restr_type_dvf = dvf.loc[
             dvf["code_type_local"].isin(types_of_interest[t])
+        ].drop("code_type_local", axis=1)
+        restr_type_avec_plm = dvf_avec_plm.loc[
+            dvf_avec_plm["code_type_local"].isin(types_of_interest[t])
         ].drop("code_type_local", axis=1)
         # échelle nationale
         intervalles, volumes = distrib_from_prix(restr_type_dvf["prix_m2"])
@@ -1039,7 +1077,7 @@ def create_distribution_and_stats_whole_period() -> None:
         for e in echelles_of_interest:
             logging.info(f"Starting {e} {t}")
             # stats
-            grouped = restr_type_dvf[[f"code_{e}", "prix_m2"]].groupby(f"code_{e}")
+            grouped = restr_type_avec_plm[[f"code_{e}", "prix_m2"]].groupby(f"code_{e}")
             nb = grouped.count().reset_index()
             nb.columns = ["code_geo", f"nb_ventes_whole_{t}"]
             mean = grouped.mean().reset_index()
@@ -1054,7 +1092,7 @@ def create_distribution_and_stats_whole_period() -> None:
             # distribution
             if echelles_of_interest[e]:
                 codes_geo = set(echelles.loc[echelles["echelle_geo"] == e, "code_geo"])
-                restr_dvf = restr_type_dvf[[f"code_{e}", "prix_m2"]].set_index(
+                restr_dvf = restr_type_avec_plm[[f"code_{e}", "prix_m2"]].set_index(
                     f"code_{e}"
                 )["prix_m2"]
                 idx = set(restr_dvf.index)

--- a/data_processing/dvf/explore/task_functions.py
+++ b/data_processing/dvf/explore/task_functions.py
@@ -3,7 +3,6 @@ import glob
 import json
 import logging
 import os
-from collections.abc import Iterable
 from datetime import datetime
 from functools import reduce
 
@@ -419,14 +418,14 @@ def filter_communes(communes: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([unique_rows, duplicate_rows]).sort_index()
 
 
-def add_communes_plm(mutations: pd.DataFrame, echelles: Iterable[str]) -> pd.DataFrame:
+def add_communes_plm(mutations: pd.DataFrame) -> pd.DataFrame:
     """Rattache les mutations des arrondissements municipaux à leur commune.
 
     Chaque mutation d'un arrondissement de Paris, Lyon ou Marseille est dupliquée
     sous le code de sa commune, de sorte que les statistiques de ces villes soient
     calculées sur leurs mutations et non agrégées depuis celles des arrondissements.
-    Les codes des autres échelles sont vidés sur ces doublons pour qu'ils ne soient
-    comptés qu'une fois par département, EPCI et section.
+    Le résultat ne vaut que pour l'échelle commune : les doublons y sont comptés une
+    fois de plus, sous un code que les autres échelles ne connaissent pas.
     """
     plm = pd.concat(
         [
@@ -436,7 +435,6 @@ def add_communes_plm(mutations: pd.DataFrame, echelles: Iterable[str]) -> pd.Dat
             for prefixe, code_commune in COMMUNES_PLM.items()
         ]
     )
-    plm[[f"code_{e}" for e in echelles if e != "commune"]] = np.nan
     return pd.concat([mutations, plm], ignore_index=True)
 
 
@@ -556,9 +554,13 @@ def process_dvf_stats() -> None:
         logging.info(
             f"Après retrait des ventes sans prix au m² et valeurs aberrantes : {len(ventes_nodup)}"
         )
-        # seules les agrégations géographiques rattachent les arrondissements à leur
-        # commune ; les stats nationales restent calculées sur les mutations réelles
-        ventes_avec_plm = add_communes_plm(ventes_nodup, echelles_of_interest)
+        # seule l'échelle commune rattache les arrondissements à leur ville ; les
+        # autres échelles et les stats nationales portent sur les mutations réelles
+        ventes_avec_plm = add_communes_plm(
+            ventes_nodup[
+                ["code_commune", "month", "type_local", "code_type_local", "prix_m2"]
+            ]
+        )
         export_intermediary = []
 
         # avoid unnecessary steps due to half years
@@ -572,7 +574,10 @@ def process_dvf_stats() -> None:
         for m in month_range:
             dfs_dict = {}
             for echelle in echelles_of_interest:
-                grouped = ventes_avec_plm.groupby(
+                ventes_echelle = (
+                    ventes_avec_plm if echelle == "commune" else ventes_nodup
+                )
+                grouped = ventes_echelle.groupby(
                     [f"code_{echelle}", "month", "type_local"]
                 )["prix_m2"]
 
@@ -622,8 +627,8 @@ def process_dvf_stats() -> None:
                 merged = pd.merge(merged, median_, on=[f"code_{echelle}"])
 
                 # appartement + maison
-                combined = ventes_avec_plm.loc[
-                    ventes_avec_plm["code_type_local"].isin([1, 2])
+                combined = ventes_echelle.loc[
+                    ventes_echelle["code_type_local"].isin([1, 2])
                 ].groupby([f"code_{echelle}", "month"])["prix_m2"]
 
                 nb = combined.count()
@@ -1038,18 +1043,12 @@ def create_distribution_and_stats_whole_period() -> None:
     dvf = dvf[
         ["code_" + e for e in echelles_of_interest] + ["code_type_local", "prix_m2"]
     ]
-    # cf. process_dvf_stats : seules les agrégations géographiques rattachent les
-    # arrondissements à leur commune, les stats nationales portent sur dvf
-    dvf_avec_plm = add_communes_plm(dvf, echelles_of_interest)
     threshold = 100
     tranches = []
     stats_period = []
     for t in types_of_interest:
         restr_type_dvf = dvf.loc[
             dvf["code_type_local"].isin(types_of_interest[t])
-        ].drop("code_type_local", axis=1)
-        restr_type_avec_plm = dvf_avec_plm.loc[
-            dvf_avec_plm["code_type_local"].isin(types_of_interest[t])
         ].drop("code_type_local", axis=1)
         # échelle nationale
         intervalles, volumes = distrib_from_prix(restr_type_dvf["prix_m2"])
@@ -1076,8 +1075,13 @@ def create_distribution_and_stats_whole_period() -> None:
         ]
         for e in echelles_of_interest:
             logging.info(f"Starting {e} {t}")
+            prix_par_code = restr_type_dvf[[f"code_{e}", "prix_m2"]]
+            # cf. process_dvf_stats : seule l'échelle commune rattache les
+            # arrondissements à leur ville
+            if e == "commune":
+                prix_par_code = add_communes_plm(prix_par_code)
             # stats
-            grouped = restr_type_avec_plm[[f"code_{e}", "prix_m2"]].groupby(f"code_{e}")
+            grouped = prix_par_code.groupby(f"code_{e}")
             nb = grouped.count().reset_index()
             nb.columns = ["code_geo", f"nb_ventes_whole_{t}"]
             mean = grouped.mean().reset_index()
@@ -1092,9 +1096,7 @@ def create_distribution_and_stats_whole_period() -> None:
             # distribution
             if echelles_of_interest[e]:
                 codes_geo = set(echelles.loc[echelles["echelle_geo"] == e, "code_geo"])
-                restr_dvf = restr_type_avec_plm[[f"code_{e}", "prix_m2"]].set_index(
-                    f"code_{e}"
-                )["prix_m2"]
+                restr_dvf = prix_par_code.set_index(f"code_{e}")["prix_m2"]
                 idx = set(restr_dvf.index)
                 operations = len(codes_geo)
                 for i, code in enumerate(codes_geo):
@@ -1136,6 +1138,9 @@ def create_distribution_and_stats_whole_period() -> None:
             else:
                 logging.info("- No distribution")
         stats_period.append(pd.concat(type_stats))
+        del restr_type_dvf
+        del type_stats
+        gc.collect()
     output_tranches = pd.DataFrame(tranches)
     output_tranches.to_csv(
         TMP_FOLDER + "distribution_prix.csv",

--- a/data_processing/dvf/explore/tests/conftest.py
+++ b/data_processing/dvf/explore/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Pytest configuration for the DVF explore tests.
+
+Stubs out Airflow, the data.gouv.fr config and the utils modules so that
+``task_functions`` can be imported and unit-tested without an Airflow runtime
+or real S3/API access.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+repo_root = Path(__file__).parent.parent.parent.parent.parent
+
+explore_dir = repo_root / "data_processing" / "dvf" / "explore"
+
+# Make the repo root importable as 'datagouvfr_data_pipelines'
+sys.path.insert(0, str(repo_root))
+
+
+def _stub_package(name, path=None, **attrs):
+    """Register a fake package in sys.modules."""
+    module = types.ModuleType(name)
+    if path is not None:
+        module.__path__ = [str(path)]
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+# --- Airflow ---
+def _task_passthrough(fn=None, **kwargs):
+    if fn is not None:
+        return fn
+
+    def decorator(f):
+        return f
+
+    return decorator
+
+
+_stub_package("airflow")
+_stub_package("airflow.sdk", task=_task_passthrough)
+
+# --- datagouvfr_data_pipelines package tree ---
+packages = [
+    ("datagouvfr_data_pipelines", repo_root),
+    ("datagouvfr_data_pipelines.data_processing", None),
+    ("datagouvfr_data_pipelines.data_processing.dvf", None),
+    # 'explore' points at the real directory so task_functions is importable
+    ("datagouvfr_data_pipelines.data_processing.dvf.explore", explore_dir),
+    ("datagouvfr_data_pipelines.utils", None),
+]
+for name, path in packages:
+    _stub_package(name, path)
+
+# --- config mock ---
+sys.modules["datagouvfr_data_pipelines.config"] = MagicMock()
+
+# --- utils modules imported by task_functions ---
+_stub_package(
+    "datagouvfr_data_pipelines.utils.conversions",
+    csv_to_csvgz=MagicMock(),
+    csv_to_geoparquet=MagicMock(),
+)
+_stub_package("datagouvfr_data_pipelines.utils.datagouv", local_client=MagicMock())
+_stub_package("datagouvfr_data_pipelines.utils.filesystem", File=MagicMock())
+_stub_package("datagouvfr_data_pipelines.utils.postgres", PostgresClient=MagicMock())
+_stub_package("datagouvfr_data_pipelines.utils.s3", S3Client=MagicMock())
+_stub_package("datagouvfr_data_pipelines.utils.tchap", send_message=MagicMock())

--- a/data_processing/dvf/explore/tests/test_task_functions.py
+++ b/data_processing/dvf/explore/tests/test_task_functions.py
@@ -1,0 +1,56 @@
+import pandas as pd
+
+from datagouvfr_data_pipelines.data_processing.dvf.explore.task_functions import (
+    add_communes_plm,
+)
+
+
+def _mutations():
+    """Une mutation par ville à arrondissements, plus une commune ordinaire."""
+    return pd.DataFrame(
+        {
+            "code_commune": ["75101", "75102", "69381", "13201", "31555"],
+            "month": [1, 2, 3, 4, 5],
+            "code_type_local": [2, 2, 1, 1, 2],
+            "prix_m2": [10000.0, 12000.0, 5000.0, 4000.0, 3000.0],
+        }
+    )
+
+
+def test_plm_communes_have_their_own_mutations():
+    out = add_communes_plm(_mutations())
+    assert sorted(out.loc[out["code_commune"] == "75056", "prix_m2"]) == [
+        10000.0,
+        12000.0,
+    ]
+    assert list(out.loc[out["code_commune"] == "69123", "prix_m2"]) == [5000.0]
+    assert list(out.loc[out["code_commune"] == "13055", "prix_m2"]) == [4000.0]
+
+
+def test_arrondissements_and_other_communes_are_kept_once():
+    out = add_communes_plm(_mutations())
+    for code in ["75101", "75102", "69381", "13201", "31555"]:
+        assert (out["code_commune"] == code).sum() == 1
+
+
+def test_duplicated_rows_keep_their_other_columns():
+    """Seul le code commune change : la duplication doit être transparente pour le
+    reste de la ligne, sans quoi les stats de la ville porteraient sur des mutations
+    amputées."""
+    out = add_communes_plm(_mutations())
+    paris_1er = out.loc[out["code_commune"] == "75101"].iloc[0]
+    duplicate = out.loc[
+        (out["code_commune"] == "75056") & (out["prix_m2"] == paris_1er["prix_m2"])
+    ].iloc[0]
+    assert duplicate["month"] == paris_1er["month"]
+    assert duplicate["code_type_local"] == paris_1er["code_type_local"]
+
+
+def test_communes_without_arrondissements_are_untouched():
+    mutations = pd.DataFrame(
+        {
+            "code_commune": ["31555", "44109"],
+            "prix_m2": [3000.0, 2500.0],
+        }
+    )
+    pd.testing.assert_frame_equal(add_communes_plm(mutations), mutations)

--- a/dgv/monitoring/dashboard/preview_stats.py
+++ b/dgv/monitoring/dashboard/preview_stats.py
@@ -243,7 +243,9 @@ def get_resource_previews(row: dict) -> tuple[list[str], list[str]]:
             except Exception:
                 pass
         raw_methods = extras.get("check:cors:allow-methods") or ""
-        allowed_methods = [m.strip().upper() for m in raw_methods.split(",") if m.strip()]
+        allowed_methods = [
+            m.strip().upper() for m in raw_methods.split(",") if m.strip()
+        ]
         supports_get = len(allowed_methods) == 0 or "GET" in allowed_methods
         cors_allowed = (has_public_cors or has_specific_cors) and supports_get
     elif extras.get("check:cors:status") is not None:
@@ -504,10 +506,7 @@ def compute_stats(resource_df: pd.DataFrame) -> tuple:
     resource_df = resource_df[archived.eq("false")]
 
     df_res = pd.DataFrame.from_dict(
-        [
-            build_resource_info_table(row)
-            for _, row in resource_df.iterrows()
-        ]
+        [build_resource_info_table(row) for _, row in resource_df.iterrows()]
     )
 
     return df_res, build_stats(df_res)
@@ -532,7 +531,7 @@ def upload_preview_stats() -> None:
 
     history_key = s3_destination_folder + history_file_name
     if s3.does_file_exist_in_bucket(history_key):
-        logging.info(f"Existing history found, appending new rows")
+        logging.info("Existing history found, appending new rows")
         history = pd.read_csv(
             StringIO(s3.get_file_content(history_key)),
             dtype="string",

--- a/dgv/monitoring/dashboard/tests/test_preview_stats.py
+++ b/dgv/monitoring/dashboard/tests/test_preview_stats.py
@@ -9,7 +9,6 @@ stats), not on renames.
 
 from pathlib import Path
 
-import pandas as pd
 import pytest
 from datagouvfr_data_pipelines.dgv.monitoring.dashboard import preview_stats as ps
 

--- a/schema/website/task_functions.py
+++ b/schema/website/task_functions.py
@@ -33,7 +33,7 @@ SCHEMA_INFOS: dict[str, Any] = {}
 SCHEMA_CATALOG: dict[str, Any] = {}
 KNOWN_TYPES = {"tableschema", "jsonschema", "other", "datapackage"}
 
-# TODO: the whole code could be refactored to separate concerns : 
+# TODO: the whole code could be refactored to separate concerns :
 # backend : schemas data should be processed and stored in a readable data model for better debugging
 # frontend : anything related to the code that should be produced based of this data model should be in separate function - and even steps
 # that would allow cleaner retries where we dont mix up data model and code writing
@@ -1118,6 +1118,7 @@ def get_template_github_issues(suffix):
                     )
     return dates
 
+
 def deduplicate_updates(updates: dict) -> bool:
     """Remove repeated entries per date and change type, keeping the first occurrence.
     Before new_version entries were made unique per schema, a schema gaining several
@@ -1249,7 +1250,7 @@ def update_news_feed(tmp_folder, suffix, **context):
     with open(schema_updates_file, "r", encoding="utf-8") as f:
         updates = json.load(f)
         f.close()
-    # TODO: this call can go once the committed file is clean and its reference later 
+    # TODO: this call can go once the committed file is clean and its reference later
     duplicates_removed = deduplicate_updates(updates)
     # the RSS feeds carry the same duplicates but are not rebuilt from schema-updates.json,
     # they are only ever appended to: they have to be cleaned separately. This runs on


### PR DESCRIPTION
- Part of https://github.com/datagouv/data.gouv.fr/issues/2087
- See also https://github.com/datagouv/explore.data.gouv.fr/pull/223/ and https://github.com/datagouv/api-dvf/pull/8

DVF mutations carry the code of their municipal arrondissement (751xx, 693xx, 132xx) and never the code of the commune itself, so Paris, Lyon and Marseille were the only communes in France without any statistics at the commune scale.

Each mutation of an arrondissement is now also attached to its commune, which keeps medians computed on the mutations themselves rather than aggregated from the arrondissement medians. The other scale codes are cleared on those duplicates so they are still counted once per departement, EPCI and section, and national stats keep using the untouched mutations.